### PR TITLE
fix(vterm): use dynamic binding instead of global binding.

### DIFF
--- a/aidermacs-backend-vterm.el
+++ b/aidermacs-backend-vterm.el
@@ -7,6 +7,10 @@
 
 (require 'vterm nil 'noerror)
 
+;; we want to ensure these two variables are dynamic binding
+(defvar vterm-shell)
+(defvar vterm-buffer-name)
+
 (defun aidermacs--vterm-output-advice (orig-fun &rest args)
   "Capture output before and after executing `vterm-send-return'.
 This advice records the current prompt position as START-POINT,
@@ -67,17 +71,12 @@ and BUFFER-NAME is the name of the vterm buffer."
                      "--dark-mode"
                    "--light-mode"))
            (cmd (mapconcat 'identity (append (list program mode) args) " "))
-           (vterm-buffer-name-orig vterm-buffer-name)
+           (vterm-buffer-name buffer-name)
+           (vterm-shell cmd)
            (vterm-shell-orig vterm-shell))
-      ;; Temporarily set globals so that the new buffer uses our values.
-      (setq vterm-buffer-name buffer-name)
-      (setq vterm-shell cmd)
       (with-current-buffer (vterm-other-window)
         (aidermacs-minor-mode 1)
-        (advice-add 'vterm-send-return :around #'aidermacs--vterm-output-advice))
-      ;; Restore the original globals.
-      (setq vterm-buffer-name vterm-buffer-name-orig)
-      (setq vterm-shell vterm-shell-orig)))
+        (advice-add 'vterm-send-return :around #'aidermacs--vterm-output-advice))))
   buffer-name)
 
 (defun aidermacs--send-command-vterm (buffer command)


### PR DESCRIPTION
This is an improved version of #10.

The key thing is that we need to make sure the two variables we want to dynamically bind should be declared by `defvar`, otherwise it will be treated as lexical binding.

Beside, we suggest we stick with the default `(vterm)` instead of `(vterm-other-window)`.

In case the user want to configure the window opening strategy, they can always configure `display-buffer-alist`, an example is as following:

the following config in user's config ensures the window open as another window. The user can configure it to whatever they want, for example my personal preference would be to open it at another tab.

```emacs-lisp

(add-to-list 'display-buffer-alist
             `("\\*aidermacs.*\\*"
               (display-buffer-pop-up-window)))
```