### PR TITLE
Remove "Detected dumb terminal" from output

### DIFF
--- a/aidermacs-backend-comint.el
+++ b/aidermacs-backend-comint.el
@@ -241,7 +241,8 @@ This allows for multi-line input without sending the command."
 
 (defun aidermacs-run-comint (program args buffer-name)
   "Create a comint-based buffer and run aidermacs PROGRAM with ARGS in BUFFER-NAME."
-  (let ((comint-terminfo-terminal "dumb"))
+  (let ((comint-terminfo-terminal "eterm-color")
+        (args (append (list "--no-pretty" "--no-fancy-input") args)))
     (unless (comint-check-proc buffer-name)
       (apply 'make-comint-in-buffer "aidermacs" buffer-name program nil args)
       (with-current-buffer buffer-name


### PR DESCRIPTION
Now that aider has option to control input and output, we don't need to use the "dumb" terminal to disable fancy input. This let's us fix the message:

Detected dumb terminal, disabling fancy input and pretty output.

That will show up if that term is used.