### PR TITLE
fix: don't switch to aider buffer before reading symbol

### DIFF
--- a/aidermacs.el
+++ b/aidermacs.el
@@ -589,8 +589,8 @@ If point is in a function, refactor that function."
 If region is active, explain that region.
 If point is in a function, explain that function."
   (interactive)
-  (aidermacs-add-current-file)
   (when-let ((command (aidermacs--form-prompt "/ask" "Explain")))
+    (aidermacs-add-current-file)
     (aidermacs--send-command command t)))
 
 ;;;###autoload

--- a/aidermacs.el
+++ b/aidermacs.el
@@ -597,13 +597,13 @@ If point is in a function, explain that function."
 (defun aidermacs-explain-symbol-under-point ()
   "Ask aidermacs to explain symbol under point, given the code line as background info."
   (interactive)
-  (aidermacs-add-current-file)
   (let* ((symbol (thing-at-point 'symbol))
          (line (buffer-substring-no-properties
                 (line-beginning-position)
                 (line-end-position)))
          (prompt (format "/ask Please explain what '%s' means in the context of this code line: %s"
                          symbol line)))
+    (aidermacs-add-current-file)    
     (aidermacs--send-command prompt t)))
 
 (defun aidermacs-send-command-with-prefix (prefix command)


### PR DESCRIPTION
When invoking `aidermacs-explain-symbol-under-point`, I noticed that aidermacs was detecting the symbol incorrectly. This seems to be a side-effect of the `(aidermacs-add-current-file)` call, which causes `(thing-at-point 'symbol)` to be called in the context of the aider buffer instead of the source buffer. Calling `(aidermacs-add-current-file)` after reading symbol fixes the problem for me.

Same for `aidermacs-function-or-region-explain`.