### PR TITLE
Fix syntax highlighting when code fence does not have mode

### DIFF
--- a/aidermacs-backend-comint.el
+++ b/aidermacs-backend-comint.el
@@ -210,7 +210,7 @@ This allows for multi-line input without sending the command."
               (mode (map-elt aidermacs-language-name-map lang lang)))
          (intern-soft (concat mode "-mode"))))
      ;; check the file extension in auto-mode-alist
-     (when (re-search-backward "^\\([^[:space:]]+\\)" (line-beginning-position -3) t)
+     (when (re-search-backward "^\\([^[:space:]`]+\\)" (line-beginning-position -3) t)
        (let ((file (match-string 1)))
          (cdr (cl-assoc-if (lambda (re) (string-match re file)) auto-mode-alist))))
      aidermacs--syntax-major-mode


### PR DESCRIPTION
When there is a search/replace block inside an mode-less code fence, The regex was matching on wrong line and not returning the correct major mode.