### PR TITLE
Use Ediff to Show Better Code Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@
 
 # Aidermacs: AI Pair Programming in Emacs
 
-Miss using [Cursor](https://cursor.sh) but prefer living in Emacs? Aidermacs brings Cursor-like AI-powered development to your Emacs workflow by integrating [Aider](https://github.com/paul-gauthier/aider), one of the most powerful open-source AI pair programming tools available. As a community-driven project, Aidermacs prioritizes the needs and preferences of Emacs users. It provides the same powerful features you'd find in Cursor:
+Missing [Cursor](https://cursor.sh) but prefer living in Emacs? Aidermacs brings Cursor-like AI-powered development to your Emacs workflow by integrating [Aider](https://github.com/paul-gauthier/aider), one of the most powerful open-source AI pair programming tools. As a community-driven project, Aidermacs prioritizes Emacs users' needs and preferences while providing the same powerful features found in Cursor!
 
-Key features:
-
+- Built-in **Ediff** integration for reviewing AI-generated changes
 - Top performance on the SWE Bench, solving real GitHub issues in major open source projects
 - Support for multi-file edits in complex codebases
 - Real-time file synchronization for true pair programming
@@ -22,14 +21,14 @@ Key features:
 
 ### Community-Driven Development
 
-Aidermacs thrives on community involvement. We believe that the best software is built collaboratively, with input from users and contributors. We encourage you to:
+Aidermacs thrives on community involvement. We believe collaborative development with user and contributor input creates the best software. We encourage you to:
 
 - Contribute Code: Submit pull requests with bug fixes, new features, or improvements to existing functionality.
 - Report Issues: Let us know about any bugs, unexpected behavior, or feature requests through GitHub Issues.
 - Share Ideas: Participate in discussions and propose new ideas for making Aidermacs even better.
 - Improve Documentation: Help us make the documentation clearer, more comprehensive, and easier to use.
 
-Your contributions are essential to making Aidermacs the best AI pair programming tool in Emacs!
+Your contributions are essential for making Aidermacs the best AI pair programming tool in Emacs!
 
 <a href = "https://github.com/MatthewZMD/aidermacs/graphs/contributors">
   <img src = "https://contrib.rocks/image?repo=MatthewZMD/aidermacs"/>
@@ -68,13 +67,13 @@ You can customize the default AI model used by Aidermacs by setting the `aiderma
 (setq aidermacs-default-model "sonnet")
 ```
 
-This allows you to easily switch between different AI models without modifying the `aidermacs-extra-args` variable.
+This enables easy switching between different AI models without modifying the `aidermacs-extra-args` variable.
 
 *Note: This configuration will be overwritten by the existence of an `.aider.conf.yml` file (see [details](#Overwrite-Configuration-with-Configuration-File)).*
 
 ### Dynamic Model Selection
 
-Aidermacs provides intelligent model selection for the solo (non-Architect) mode that automatically detects and integrates with multiple AI providers:
+Aidermacs offers intelligent model selection for solo (non-Architect) mode, automatically detecting and integrating with multiple AI providers:
 
 - Automatically fetches available models from supported providers (OpenAI, Anthropic, DeepSeek, Google Gemini, OpenRouter)
 - Caches model lists for quick access
@@ -97,7 +96,7 @@ The system will automatically filter models to only show ones that are:
 
 ### Architect Mode - Separating Code Reasoning and Editing Models
 
-Aidermacs supports an experimental mode that leverages two models for each coding task: an Architect model for reasoning and an Editor model for generating code edits. This approach has **achieved state-of-the-art (SOTA) results on aider's code editing benchmark**, as detailed in [this blog post](https://aider.chat/2024/09/26/architect.html).
+Aidermacs features an experimental mode using two specialized models for each coding task: an Architect model for reasoning and an Editor model for code generation. This approach has **achieved state-of-the-art (SOTA) results on aider's code editing benchmark**, as detailed in [this blog post](https://aider.chat/2024/09/26/architect.html).
 
 To enable this mode, set `aidermacs-use-architect-mode` to `t`. You must also configure the `aidermacs-architect-model` variable to specify the model to use for the Architect role.
 
@@ -117,7 +116,7 @@ When Architect mode is enabled, the `aidermacs-default-model` setting is ignored
 
 Choose your preferred terminal backend by setting `aidermacs-backend`:
 
-`vterm` provides better terminal compatibility, while `comint` is a simple, built-in option that's still fully compatible with aidermacs.
+`vterm` offers better terminal compatibility, while `comint` provides a simple, built-in option that remains fully compatible with Aidermacs.
 
 ```emacs-lisp
 ;; Use vterm backend (default is comint)
@@ -142,20 +141,20 @@ You can customize keybindings for multiline input, this key allows you to enter 
 
 ### Re-Enable Auto-Commits
 
-Aider by default automatically commits changes made by the AI. We find this behavior *very* intrusive, so we disabled it for you. You can re-enable auto-commits by setting `aidermacs-auto-commits` to `t`:
+Aider automatically commits AI-generated changes by default. We consider this behavior *very* intrusive, so we've disabled it. You can re-enable auto-commits by setting `aidermacs-auto-commits` to `t`:
 
 ```emacs-lisp
 ;; Enable auto-commits
 (setq aidermacs-auto-commits t)
 ```
 
-With auto-commits disabled, you'll need to manually commit changes using your preferred Git workflow.
+With auto-commits disabled, you must manually commit changes using your preferred Git workflow.
 
 *Note: This configuration will be overwritten by the existence of an `.aider.conf.yml` file (see [details](#Overwrite-Configuration-with-Configuration-File)).*
 
 ### Customizing Aider Options with `aidermacs-extra-args`
 
-If the above configurations aren't enough already, the `aidermacs-extra-args` variable allows you to pass any command-line options supported by Aider.
+If these configurations aren't sufficient, the `aidermacs-extra-args` variable enables passing any Aider-supported command-line options.
 
 See the [Aider configuration documentation](https://aider.chat/docs/config/options.html) for a full list of available options.
 
@@ -328,29 +327,36 @@ While `aider.el` strictly mirrors Aider's CLI behavior, `Aidermacs` is built aro
 
 With `Aidermacs`, you get:
 
-1. Intelligent Model Selection
+1. Built-in Ediff Integration for AI-Generated Changes
+   - Seamless Code Review: Automatically shows diffs for all AI-modified files using Emacs' powerful `ediff` interface
+   - Familiar Interface: Uses Emacs' native `ediff` workflow for reviewing changes
+   - Interactive Workflow: Accept or reject changes with standard `ediff` commands
+   - Syntax Highlighting: Maintains proper syntax highlighting during comparisons
+   - Safe Change Management: Preserves original file states for easy comparison and rollback
+
+2. Intelligent Model Selection
    - Automatic discovery of available models from multiple providers
    - Real-time model compatibility checking
    - Seamless integration with your configured API keys
    - Caching for quick access to frequently used models
    - Support for both popular pre-configured models and dynamically discovered ones
 
-2. Flexible Terminal Backend Support
+3. Flexible Terminal Backend Support
    - `Aidermacs` supports multiple terminal backends (comint and vterm) for better compatibility and performance
    - Easy configuration to choose your preferred terminal emulation
    - Extensible architecture for adding new backends
 
-3. Smarter Syntax Highlighting
+4. Smarter Syntax Highlighting
    - AI-generated code appears with proper syntax highlighting in major languages.
    - Ensures clarity and readability without additional configuration.
 
-4. Better Support for Multiline Input
+5. Better Support for Multiline Input
    - `aider` is primarily designed as a command-line program, where multiline input is restricted by terminal limitations.
    - Terminal-based tools require special syntax or manual formatting to handle multiline input, which can be cumbersome and unintuitive.
    - `Aidermacs` eliminates these restrictions by handling multiline prompts natively within Emacs, allowing you to compose complex AI requests just like any other text input.
    - Whether you're pasting blocks of code or refining AI-generated responses, multiline interactions in `Aidermacs` feel natural and seamless.
 
-5. Enhanced File Management from Emacs
+6. Enhanced File Management from Emacs
    - List files currently in chat with `M-x aidermacs-list-added-files`
    - Drop specific files from chat with `M-x aidermacs-drop-file`
    - View output history with `M-x aidermacs-show-output-history`
@@ -359,17 +365,17 @@ With `Aidermacs`, you get:
    - Create a temporary file for adding code snippets or notes to the Aider session with `M-x aidermacs-create-session-scratchpad`
    - and more
 
-6. Greater Configurability
+7. Greater Configurability
    - `Aidermacs` offers more customization options to tailor the experience to your preferences.
 
-7. Streamlined Transient Menu Selection
+8. Streamlined Transient Menu Selection
    - The transient menus have been completely redesigned to encompass functionality and ergonomics, prioritizing user experience.
 
-8. Flexible Ways to Add Content
+9. Flexible Ways to Add Content
    - `Aidermacs` provides multiple ways to add content to the Aider session, including adding files, creating temporary scratchpad files, and more.
 
-9. Community-Driven Development
-   - `Aidermacs` is actively developed and maintained by the community, incorporating user feedback and contributions.
-   - We prioritize features and improvements that directly benefit Emacs users, ensuring a tool that evolves with your needs.
+10. Community-Driven Development
+    - `Aidermacs` is actively developed and maintained by the community, incorporating user feedback and contributions.
+    - We prioritize features and improvements that directly benefit Emacs users, ensuring a tool that evolves with your needs.
 
 ... and more to come 🚀

--- a/aidermacs-backend-comint.el
+++ b/aidermacs-backend-comint.el
@@ -24,6 +24,11 @@
 
 (require 'comint)
 
+;; Forward declarations
+(declare-function aidermacs--prepare-for-code-edit "aidermacs")
+(declare-function aidermacs--cleanup-all-temp-files "aidermacs")
+(declare-function aidermacs--show-ediff-for-edited-files "aidermacs")
+(declare-function aidermacs--detect-edited-files "aidermacs")
 (declare-function aidermacs--process-message-if-multi-line "aidermacs" (str))
 
 (defcustom aidermacs-language-name-map '(("elisp" . "emacs-lisp")

--- a/aidermacs-backend-comint.el
+++ b/aidermacs-backend-comint.el
@@ -109,10 +109,10 @@ that was matched at the start of the current syntax block.")
       (aidermacs--store-output aidermacs--comint-output-temp)
       ;; Check if any files were edited and show ediff if needed
       (let ((edited-files (aidermacs--detect-edited-files)))
-        (when edited-files
-          (aidermacs--show-ediff-for-edited-files edited-files)))
-      (setq aidermacs--comint-output-temp "")
-      (aidermacs--cleanup-all-temp-files))))
+        (if edited-files
+            (aidermacs--show-ediff-for-edited-files edited-files)
+          (aidermacs--cleanup-all-temp-files)))
+      (setq aidermacs--comint-output-temp ""))))
 
 (defun aidermacs-reset-font-lock-state ()
   "Reset font lock state to default for processing a new source block."

--- a/aidermacs-backend-comint.el
+++ b/aidermacs-backend-comint.el
@@ -272,9 +272,10 @@ PROC is the process to send to.  STRING is the command to send."
   (aidermacs-reset-font-lock-state)
   ;; Store the command for tracking in the correct buffer
   (with-current-buffer (process-buffer proc)
-    (setq-local aidermacs--last-command string)
-    ;; Always prepare for potential edits
-    (aidermacs--prepare-for-code-edit))
+    (unless (member string '("" "y" "n" "d" "yes" "no"))
+      (setq aidermacs--last-command string)
+      ;; Always prepare for potential edits
+      (aidermacs--prepare-for-code-edit)))
   (comint-simple-send proc (aidermacs--process-message-if-multi-line string)))
 
 (defun aidermacs-run-comint (program args buffer-name)

--- a/aidermacs-backend-vterm.el
+++ b/aidermacs-backend-vterm.el
@@ -172,6 +172,7 @@ BUFFER-NAME is the name for the vterm buffer."
                     aidermacs--vterm-last-check-point nil)
         (advice-add 'vterm-send-return :around #'aidermacs--vterm-output-advice)
         (advice-add 'vterm-send-return :before #'aidermacs--vterm-capture-keyboard-input)
+        (advice-add 'vterm--self-insert :after #'aidermacs--cleanup-temp-files-on-interrupt-vterm)
         ;; Set up multi-line key binding
         (let ((map (make-sparse-keymap)))
           (set-keymap-parent map (current-local-map))
@@ -224,6 +225,13 @@ ORIG-FUN is the original function being advised. ARGS are its arguments."
     (setq-local aidermacs--vterm-active-timer nil))
   (setq-local aidermacs--vterm-last-check-point nil)
   (advice-remove 'vterm-send-return #'aidermacs--vterm-capture-keyboard-input))
+
+(defun aidermacs--cleanup-temp-files-on-interrupt-vterm (&rest args)
+  "Run `aidermacs--cleanup-all-temp-files' after interrupting a vterm subjob.
+ARGS are the arguments."
+  (when (and (aidermacs--is-aidermacs-buffer-p)
+             (equal (this-command-keys) "\C-c\C-c"))
+    (aidermacs--cleanup-all-temp-files)))
 
 (provide 'aidermacs-backend-vterm)
 

--- a/aidermacs-backend-vterm.el
+++ b/aidermacs-backend-vterm.el
@@ -94,13 +94,13 @@ If the finish sequence is detected, store the output via
 
             ;; If we found a shell prompt
             (when (string-match-p expected prompt-line)
-              (let ((output (buffer-substring-no-properties start-point seq-start)))
+              (let ((output (buffer-substring-no-properties start-point seq-start))
+                    (edited-files (aidermacs--detect-edited-files)))
                 (aidermacs--store-output (string-trim output))
                 ;; Check if any files were edited and show ediff if needed
-                (let ((edited-files (aidermacs--detect-edited-files)))
-                  (when edited-files
-                    (aidermacs--show-ediff-for-edited-files edited-files)))
-                (aidermacs--cleanup-all-temp-files))
+                (if edited-files
+                    (aidermacs--show-ediff-for-edited-files edited-files)
+                  (aidermacs--cleanup-all-temp-files)))
               (set-process-filter proc orig-filter))))))))
 
 (defun aidermacs--vterm-output-advice (orig-fun &rest args)

--- a/aidermacs-backend-vterm.el
+++ b/aidermacs-backend-vterm.el
@@ -203,6 +203,7 @@ ORIG-FUN is the original function being advised. ARGS are its arguments."
   (when (and (aidermacs--is-aidermacs-buffer-p)
              (eq this-command 'vterm-send-return))
     ;; Get the current line content which should be the command
+    ;; TODO: current line may not be enough
     (save-excursion
       (let* ((prompt-point (condition-case nil
                                (vterm--get-prompt-point)

--- a/aidermacs-backend-vterm.el
+++ b/aidermacs-backend-vterm.el
@@ -55,14 +55,6 @@
   :type 'string
   :group 'aidermacs)
 
-(defun aidermacs--is-aidermacs-vterm-buffer-p (&optional buffer)
-  "Check if BUFFER is an aidermacs vterm buffer.
-If BUFFER is nil, check the current buffer.
-Returns non-nil if the buffer name matches the aidermacs buffer pattern."
-  (let ((buf (or buffer (current-buffer))))
-    (and (derived-mode-p 'vterm-mode)
-         (string-match-p "^\\*aidermacs:" (buffer-name buf)))))
-
 (defun aidermacs--vterm-check-finish-sequence-repeated (proc orig-filter start-point expected)
   "Check for the finish sequence in PROC's buffer.
 PROC is the process to check.  ORIG-FILTER is the original process filter.
@@ -109,7 +101,7 @@ pattern to match.  If the finish sequence is detected, store the output via
 ORIG-FUN is the original function being advised.  ARGS are its arguments.
 This sets a temporary process filter that checks for the finish sequence
 after each output chunk, reducing the need for timers."
-  (if (aidermacs--is-aidermacs-vterm-buffer-p)
+  (if (aidermacs--is-aidermacs-buffer-p)
       (let* ((start-point (condition-case nil
                               (vterm--get-prompt-point)
                             (error (point-min))))

--- a/aidermacs-backend-vterm.el
+++ b/aidermacs-backend-vterm.el
@@ -38,6 +38,12 @@
 (declare-function vterm-send-return "vterm")
 (declare-function vterm-insert "vterm")
 
+(declare-function aidermacs--prepare-for-code-edit "aidermacs")
+(declare-function aidermacs--cleanup-all-temp-files "aidermacs")
+(declare-function aidermacs--show-ediff-for-edited-files "aidermacs")
+(declare-function aidermacs--detect-edited-files "aidermacs")
+(declare-function aidermacs--store-output "aidermacs")
+(declare-function aidermacs--is-aidermacs-buffer-p "aidermacs")
 
 (defvar-local aidermacs--vterm-active-timer nil
   "Store the active timer for vterm output processing.")

--- a/aidermacs-backends.el
+++ b/aidermacs-backends.el
@@ -182,25 +182,19 @@ and is using either comint or vterm mode."
                (and (fboundp 'vterm-mode)
                     (derived-mode-p 'vterm-mode)))))))
 
-(defun aidermacs--send-command-backend (buffer command)
-  "Send command to buffer using the appropriate backend.
-BUFFER is the target buffer.  COMMAND is the text to send."
-  (setq aidermacs--last-command command
-        aidermacs--current-output nil)
-  (if (eq aidermacs-backend 'vterm)
-      (aidermacs--send-command-vterm buffer command)
-    (aidermacs--send-command-comint buffer command)))
-
-(defun aidermacs--send-command-redirect-backend (buffer command &optional callback)
+(defun aidermacs--send-command-backend (buffer command &optional redirect callback)
   "Send command to buffer using the appropriate backend.
 BUFFER is the target buffer.  COMMAND is the text to send.
-CALLBACK if provided will be called with the command output when available."
+If REDIRECT is non-nil it redirects the output (hidden) for comint backend.
+If CALLBACK is non-nil it will be called after the command finishes."
   (setq aidermacs--last-command command
         aidermacs--current-output nil
         aidermacs--current-callback callback)
   (if (eq aidermacs-backend 'vterm)
       (aidermacs--send-command-vterm buffer command)
-    (aidermacs--send-command-redirect-comint buffer command)))
+    (if redirect
+        (aidermacs--send-command-redirect-comint buffer command)
+      (aidermacs--send-command-comint buffer command))))
 
 (provide 'aidermacs-backends)
 

--- a/aidermacs-backends.el
+++ b/aidermacs-backends.el
@@ -54,14 +54,14 @@ of using a comint process."
   :type 'integer
   :group 'aidermacs-output)
 
-(defvar aidermacs--output-history nil
+(defvar-local aidermacs--output-history nil
   "List to store aidermacs output history.
 Each entry is a cons cell (timestamp . output-text).")
 
-(defvar aidermacs--last-command nil
+(defvar-local aidermacs--last-command nil
   "Store the last command sent to aidermacs.")
 
-(defvar aidermacs--current-output ""
+(defvar-local aidermacs--current-output ""
   "Accumulator for current output being captured as a string.")
 
 (defun aidermacs-get-output-history (&optional limit)
@@ -78,10 +78,10 @@ Returns a list of (timestamp . output-text) pairs, most recent first."
   (interactive)
   (setq aidermacs--output-history nil))
 
-(defvar aidermacs--current-callback nil
+(defvar-local aidermacs--current-callback nil
   "Store the callback function for the current command.")
 
-(defvar aidermacs--in-callback nil
+(defvar-local aidermacs--in-callback nil
   "Flag to prevent recursive callbacks.")
 
 (defun aidermacs--store-output (output)

--- a/aidermacs-backends.el
+++ b/aidermacs-backends.el
@@ -106,7 +106,8 @@ Remove any files that don't exist."
 (defun aidermacs--parse-output-for-files (output)
   "Parse OUTPUT for files and add them to `aidermacs--tracked-files'."
   (when output
-    (let ((lines (split-string output "\n")))
+    (let ((lines (split-string output "\n"))
+          (last-line ""))
       (dolist (line lines)
         (cond
          ;; Applied edit to <filename>
@@ -144,14 +145,14 @@ Remove any files that don't exist."
               (add-to-list 'aidermacs--tracked-files file))))
 
          ;; <file>\nAdd file to the chat?
-         ((string-match "\\(\\./\\)?\\(.+\\)\nAdd file to the chat?" line)
-          (when-let ((file (match-string 2 line)))
-            (add-to-list 'aidermacs--tracked-files file)))
+         ((string-match "Add file to the chat?" line)
+          (add-to-list 'aidermacs--tracked-files last-line))
 
          ;; <file> is already in the chat as an editable file
          ((string-match "\\(\\./\\)?\\(.+\\) is already in the chat as an editable file" line)
           (when-let ((file (match-string 2 line)))
-            (add-to-list 'aidermacs--tracked-files file)))))
+            (add-to-list 'aidermacs--tracked-files file))))
+        (setq last-line line))
 
       ;; Verify all tracked files exist
       (aidermacs--verify-tracked-files))))

--- a/aidermacs-backends.el
+++ b/aidermacs-backends.el
@@ -188,7 +188,6 @@ BUFFER is the target buffer.  COMMAND is the text to send.
 If REDIRECT is non-nil it redirects the output (hidden) for comint backend.
 If CALLBACK is non-nil it will be called after the command finishes."
   (setq aidermacs--last-command command
-        aidermacs--current-output nil
         aidermacs--current-callback callback)
   (if (eq aidermacs-backend 'vterm)
       (aidermacs--send-command-vterm buffer command)

--- a/aidermacs-backends.el
+++ b/aidermacs-backends.el
@@ -96,7 +96,7 @@ If there's a callback function, call it with the output."
   (unless aidermacs--in-callback
     (when aidermacs--current-callback
       (let ((aidermacs--in-callback t))
-        (funcall aidermacs--current-callback output)
+        (funcall aidermacs--current-callback)
         (setq aidermacs--current-callback nil)))))
 
 ;; Backend dispatcher functions
@@ -110,6 +110,18 @@ BUFFER-NAME is the name for the aidermacs buffer."
     (aidermacs-run-vterm program args buffer-name))
    (t
     (aidermacs-run-comint program args buffer-name))))
+
+(defun aidermacs--is-aidermacs-buffer-p (&optional buffer)
+  "Check if BUFFER is any type of aidermacs buffer.
+If BUFFER is nil, check the current buffer.
+Returns non-nil if the buffer name matches the aidermacs buffer pattern
+and is using either comint or vterm mode."
+  (let ((buf (or buffer (current-buffer))))
+    (with-current-buffer buf
+      (and (string-match-p "^\\*aidermacs:" (buffer-name buf))
+           (or (derived-mode-p 'comint-mode)
+               (and (fboundp 'vterm-mode)
+                    (derived-mode-p 'vterm-mode)))))))
 
 (defun aidermacs--send-command-backend (buffer command)
   "Send command to buffer using the appropriate backend.

--- a/aidermacs-backends.el
+++ b/aidermacs-backends.el
@@ -113,24 +113,49 @@ Looks for patterns like 'Applied edit to <filename>' and similar."
       (dolist (line lines)
         (cond
          ;; Applied edit to <filename>
-         ((string-match "Applied edit to \\(.+\\)" line)
-          (when-let ((file (match-string 1 line)))
+         ((string-match "Applied edit to \\(\\./\\)?\\(.+\\)" line)
+          (when-let ((file (match-string 2 line)))
             (add-to-list 'aidermacs--tracked-files file)))
 
          ;; Added <filename> to the chat.
-         ((string-match "Added \\(.+\\) to the chat" line)
-          (when-let ((file (match-string 1 line)))
+         ((string-match "Added \\(\\./\\)?\\(.+\\) to the chat" line)
+          (when-let ((file (match-string 2 line)))
             (add-to-list 'aidermacs--tracked-files file)))
 
-         ;; Removed <filename> from the chat
-         ((string-match "Removed \\(.+\\) from the chat" line)
-          (when-let ((file (match-string 1 line)))
+         ;; Removed <filename> from the chat (with or without ./ prefix)
+         ((string-match "Removed \\(\\./\\)?\\(.+\\) from the chat" line)
+          (when-let ((file (match-string 2 line)))
             (setq aidermacs--tracked-files (delete file aidermacs--tracked-files))))
 
          ;; Added <filename> to read-only files.
-         ((string-match "Added \\(.+\\) to read-only files" line)
-          (when-let ((file (match-string 1 line)))
-            (add-to-list 'aidermacs--tracked-files (concat file " (read-only)"))))))
+         ((string-match "Added \\(\\./\\)?\\(.+\\) to read-only files" line)
+          (when-let ((file (match-string 2 line)))
+            (add-to-list 'aidermacs--tracked-files (concat file " (read-only)"))))
+
+         ;; Moved <file> from editable to read-only files in the chat
+         ((string-match "Moved \\(\\./\\)?\\(.+\\) from editable to read-only files in the chat" line)
+          (when-let ((file (match-string 2 line)))
+            (let ((editable-file (replace-regexp-in-string " (read-only)$" "" file)))
+              (setq aidermacs--tracked-files (delete editable-file aidermacs--tracked-files))
+              (add-to-list 'aidermacs--tracked-files (concat file " (read-only)")))))
+
+         ;; Moved <file> from read-only to editable files in the chat
+         ((string-match "Moved \\(\\./\\)?\\(.+\\) from read-only to editable files in the chat" line)
+          (when-let ((file (match-string 2 line)))
+            (let ((read-only-file (concat file " (read-only)")))
+              (setq aidermacs--tracked-files (delete read-only-file aidermacs--tracked-files))
+              (add-to-list 'aidermacs--tracked-files file))))
+
+         ;; <file>\nAdd file to the chat?
+         ((string-match "\\(\\./\\)?\\(.+\\)\nAdd file to the chat?" line)
+          (when-let ((file (match-string 2 line)))
+            (add-to-list 'aidermacs--tracked-files file)))
+
+         ;; <file> is already in the chat as an editable file
+         ((string-match "\\(\\./\\)?\\(.+\\) is already in the chat as an editable file" line)
+          (when-let ((file (match-string 2 line)))
+            (add-to-list 'aidermacs--tracked-files file)))))
+
       ;; Verify all tracked files exist
       (aidermacs--verify-tracked-files))))
 

--- a/aidermacs-backends.el
+++ b/aidermacs-backends.el
@@ -26,12 +26,10 @@
 (when (commandp 'vterm)
   (require 'aidermacs-backend-vterm))
 
-(declare-function aidermacs-run-vterm "aidermacs-backend-vterm"
-                  (program args buffer-name))
-(declare-function aidermacs--send-command-vterm "aidermacs-backend-vterm"
-                  (buffer command))
-(declare-function aidermacs-project-root "aidermacs"
-                  ())
+(declare-function aidermacs-run-vterm "aidermacs-backend-vterm" (program args buffer-name))
+(declare-function aidermacs--send-command-vterm "aidermacs-backend-vterm" (buffer command))
+(declare-function aidermacs-project-root "aidermacs" ())
+(declare-function aidermacs--get-files-in-session "aidermacs" (callback))
 
 (defgroup aidermacs-backends nil
   "Backend customization for aidermacs."
@@ -39,7 +37,7 @@
 
 (defcustom aidermacs-backend 'comint
   "Backend to use for the aidermacs process.
-Options are `'comint' (the default) or `'vterm'.  When set to `'vterm',
+Options are `comint' (the default) or `vterm'.  When set to `vterm',
 aidermacs launches a fully functional vterm buffer instead
 of using a comint process."
   :type '(choice (const :tag "Comint" comint)
@@ -91,7 +89,7 @@ Returns a list of (timestamp . output-text) pairs, most recent first."
 This is used to avoid having to run /ls repeatedly.")
 
 (defun aidermacs--verify-tracked-files ()
-  "Verify if files in `aidermacs--tracked-files` exist relative to the project root.
+  "Verify files in `aidermacs--tracked-files` exist.
 Remove any files that don't exist."
   (let ((project-root (aidermacs-project-root))
         (valid-files nil))
@@ -106,8 +104,7 @@ Remove any files that don't exist."
     (setq aidermacs--tracked-files valid-files)))
 
 (defun aidermacs--parse-output-for-files (output)
-  "Parse OUTPUT for mentions of files and add them to `aidermacs--tracked-files`.
-Looks for patterns like 'Applied edit to <filename>' and similar."
+  "Parse OUTPUT for files and add them to `aidermacs--tracked-files'."
   (when output
     (let ((lines (split-string output "\n")))
       (dolist (line lines)

--- a/aidermacs-models.el
+++ b/aidermacs-models.el
@@ -134,12 +134,12 @@ This is a private function used internally."
 This fetches models from various API providers and caches them."
   (aidermacs--send-command-redirect
    "/models /"
-   (lambda (output)
+   (lambda ()
      (let* ((supported-models
              (seq-filter
               (lambda (line)
                 (string-prefix-p "- " line))
-              (split-string output "\n" t)))
+              (split-string aidermacs--current-output "\n" t)))
             (models nil))
        (setq supported-models
              (mapcar (lambda (line)

--- a/aidermacs-models.el
+++ b/aidermacs-models.el
@@ -26,8 +26,7 @@
 (require 'json)
 (require 'url)
 
-(declare-function aidermacs--send-command "aidermacs" (command &optional switch-to-buffer))
-(declare-function aidermacs--send-command-redirect "aidermacs" (command callback))
+(declare-function aidermacs--send-command "aidermacs" (command &optional no-switch-to-buffer use-existing redirect callback))
 (declare-function aidermacs-buffer-name "aidermacs" ())
 (declare-function aidermacs-exit "aidermacs" ())
 
@@ -126,14 +125,14 @@ This is a private function used internally."
   (condition-case nil
       (let ((model (completing-read "Select AI model: " aidermacs--cached-models nil t)))
         (when model
-          (aidermacs--send-command (format "/model %s" model) t)))
+          (aidermacs--send-command (format "/model %s" model))))
     (quit (message "Model selection cancelled"))))
 
 (defun aidermacs--get-available-models ()
   "Get list of models supported by aider using the /models command.
 This fetches models from various API providers and caches them."
-  (aidermacs--send-command-redirect
-   "/models /"
+  (aidermacs--send-command
+   "/models /" nil nil t
    (lambda ()
      (let* ((supported-models
              (seq-filter

--- a/aidermacs-models.el
+++ b/aidermacs-models.el
@@ -175,8 +175,8 @@ This is useful when available models have changed."
   (interactive)
   (when (and aidermacs--cached-models
              (equal aidermacs--cached-models aidermacs-popular-models)
-             (fboundp 'aidermacs-buffer-name)
-             (get-buffer (aidermacs-buffer-name)))
+             (fboundp 'aidermacs-get-buffer-name)
+             (get-buffer (aidermacs-get-buffer-name)))
     (setq aidermacs--cached-models nil))
 
   (if aidermacs--cached-models

--- a/aidermacs.el
+++ b/aidermacs.el
@@ -98,7 +98,7 @@ This is the file name without path."
   :type 'string
   :group 'aidermacs)
 
-(defvar aidermacs-read-string-history nil
+(defvar-local aidermacs-read-string-history nil
   "History list for aidermacs read string inputs.")
 
 ;;;###autoload

--- a/aidermacs.el
+++ b/aidermacs.el
@@ -478,7 +478,7 @@ Returns a deduplicated list of such file names."
 (defun aidermacs--get-files-in-session (callback)
   "Get list of files in current session and call CALLBACK with the result."
   (aidermacs--send-command
-   "/ls" nil t
+   "/ls" nil nil t
    (lambda ()
      (let ((files (aidermacs--parse-ls-output aidermacs--current-output)))
        (funcall callback files)))))

--- a/aidermacs.el
+++ b/aidermacs.el
@@ -348,12 +348,14 @@ If the current buffer is already the aidermacs buffer, do nothing."
 (defun aidermacs-clear-chat-history ()
   "Send the command \"/clear\" to the aidermacs buffer."
   (interactive)
+  (setq aidermacs--tracked-files nil)
   (aidermacs--send-command "/clear"))
 
 ;;;###autoload
 (defun aidermacs-reset ()
   "Send the command \"/reset\" to the aidermacs buffer."
   (interactive)
+  (setq aidermacs--tracked-files nil)
   (aidermacs--send-command "/reset"))
 
 ;;;###autoload
@@ -450,7 +452,8 @@ Returns a deduplicated list of such file names."
             (forward-line 1)))
 
         ;; Remove duplicates and return
-        (delete-dups (nreverse files))))))
+        (setq aidermacs--tracked-files (delete-dups (nreverse files)))
+        aidermacs--tracked-files))))
 
 ;;;###autoload
 (defun aidermacs-list-added-files ()

--- a/aidermacs.el
+++ b/aidermacs.el
@@ -296,8 +296,8 @@ This is useful for working in monorepos where you want to limit aider's scope."
   "Get list of files in current session and call CALLBACK with the result."
   (aidermacs--send-command-redirect
    "/ls"
-   (lambda (output)
-     (let ((files (aidermacs--parse-ls-output output)))
+   (lambda ()
+     (let ((files (aidermacs--parse-ls-output aidermacs--current-output)))
        (funcall callback files)))))
 
 (defun aidermacs--send-command (command &optional switch-to-buffer use-existing)


### PR DESCRIPTION
The long-awaited feature...

After Aidermacs makes modifications, an Ediff window will automatically pop up for a before-and-after comparison. You can use Ediff shortcuts like ‘a’ and ‘b’ to revert to the pre-modification state, or manually edit the buffer to fine-tune the content. This is far more powerful than simply choosing accept/reject.. the Emacs ecosystem truly rocks!

Will close #43 and tninja/aider.el#98

WIP.