### PR TITLE
fix(aidermacs-models): ensure correct parsing by moving to end of headers

### DIFF
--- a/aidermacs-models.el
+++ b/aidermacs-models.el
@@ -102,6 +102,7 @@ API provider."
              (if (string= hostname "generativelanguage.googleapis.com")
                  (concat url "/models?key=" token)
                (concat url "/models"))))
+        (goto-char url-http-end-of-headers)
         (let* ((json-object-type 'alist)
                (json-data (json-read))
                (models (if (string= hostname "generativelanguage.googleapis.com")


### PR DESCRIPTION
跳过HTTP headers，确保 json-read 能够读到完整的 response body