### PR TITLE
Add Tramp Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,25 @@ You can customize keybindings for multiline input, this key allows you to enter 
 (setq aidermacs-vterm-multiline-newline-key "S-<return>")
 ```
 
+### Remote File Support with Tramp
+
+Aidermacs fully supports working with remote files through Emacs' Tramp mode. This allows you to use Aidermacs on files hosted on remote servers via SSH, Docker, and other protocols supported by Tramp.
+
+When working with remote files:
+- File paths are automatically localized for the remote system
+- All Aidermacs features work seamlessly across local and remote files
+- Edits are applied directly to the remote files
+- Diffs and change reviews work as expected
+
+Example usage:
+```emacs-lisp
+;; Open a remote file via SSH
+(find-file "/ssh:user@remotehost:/path/to/file.py")
+
+;; Start Aidermacs session - it will automatically detect the remote context
+M-x aidermacs-transient-menu
+```
+
 ### Diff and Change Review
 
 Control whether to show diffs for AI-generated changes with `aidermacs-show-diff-after-change`:
@@ -379,6 +398,7 @@ With `Aidermacs`, you get:
    - Interactively select files to add with `M-x aidermacs-add-files-interactively`
    - Add content from any file to a specific session with `M-x aidermacs-add-file-to-session`
    - Create a temporary file for adding code snippets or notes to the Aider session with `M-x aidermacs-create-session-scratchpad`
+   - Full support for remote files via Tramp (SSH, Docker, etc.)
    - and more
 
 7. Greater Configurability

--- a/aidermacs-backends.el
+++ b/aidermacs-backends.el
@@ -91,7 +91,8 @@ This is used to avoid having to run /ls repeatedly.")
 (defun aidermacs--verify-tracked-files ()
   "Verify files in `aidermacs--tracked-files` exist.
 Remove any files that don't exist."
-  (let ((project-root (aidermacs-project-root))
+  (let* ((project-root (aidermacs-project-root))
+         (is-remote (file-remote-p project-root))
         (valid-files nil))
     (dolist (file aidermacs--tracked-files)
       (let* ((is-readonly (string-match-p " (read-only)$" file))
@@ -99,7 +100,7 @@ Remove any files that don't exist."
                               (substring file 0 (- (length file) 12))
                             file))
              (full-path (expand-file-name actual-file project-root)))
-        (when (file-exists-p full-path)
+        (when (or (file-exists-p full-path) is-remote)
           (push file valid-files))))
     (setq aidermacs--tracked-files valid-files)))
 


### PR DESCRIPTION
This commit adds support for using aidermacs via tramp. Interestingly enough the functionality was written almost completely with aider. Wild times!

The main things are:

1. Processing file names before sending them to commands like `/add`, `/read`, etc.

2. Handling output from `/ls` related commands to handle remote files

I've tested the following (in a tramp session):

- Starting a tramp session
- Adding a file
- Adding current file
- Removing a file
- Removing current file
- Listing files