### PR TITLE
add options to groups

### DIFF
--- a/aidermacs-backend-comint.el
+++ b/aidermacs-backend-comint.el
@@ -48,7 +48,8 @@
                                          ("cpp" . "c++"))
   "Map external language names to Emacs names."
   :type '(alist :key-type (string :tag "Language Name/Alias")
-                :value-type (string :tag "Mode Name (without -mode)")))
+                :value-type (string :tag "Mode Name (without -mode)"))
+  :group 'aidermacs-backend-comint)
 
 ;; FIXME: Hmm... seems to use standard diff3 markers.  Maybe some code
 ;; in `smerge-mode.el' could be (re)used?
@@ -62,7 +63,8 @@
 (defcustom aidermacs-comint-multiline-newline-key "S-<return>"
   "Key binding for `comint-accumulate' in Aidermacs buffers.
 This allows for multi-line input without sending the command."
-  :type 'string)
+  :type 'string
+  :group 'aidermacs-backend-comint)
 
 (defface aidermacs-command-separator
   '((((type graphic)) :strike-through t :extend t)

--- a/aidermacs-backend-vterm.el
+++ b/aidermacs-backend-vterm.el
@@ -69,7 +69,8 @@
 
 (defcustom aidermacs-vterm-multiline-newline-key "S-<return>"
   "Key binding to enter a newline without sending in vterm."
-  :type 'string)
+  :type 'string
+  :group 'aidermacs-backend-vterm)
 
 (defun aidermacs--vterm-check-finish-sequence-repeated (proc orig-filter start-point)
   "Check for the finish sequence in PROC's buffer.
@@ -158,7 +159,8 @@ Use BUFFER if provided, otherwise retrieve it from `aidermacs-get-buffer-name'."
 (defcustom aidermacs-vterm-use-theme-colors t
   "Whether to use Emacs theme colors for aider.
 Has effect only when using the vterm backend."
-  :type 'boolean)
+  :type 'boolean
+  :group 'aidermacs-backend-vterm)
 
 (defcustom aidermacs-vterm-theme-colors-plist
   '("--user-input-color" font-lock-function-name-face
@@ -168,7 +170,8 @@ Has effect only when using the vterm backend."
   "Emacs faces to use for aider colour flags.
 Keys are the commandline arguments to send to aider.
 Values are either faces or strings (colours like \"#00cc00\")."
-  :type 'plist)
+  :type 'plist
+  :group 'aidermacs-backend-vterm)
 
 (defun aidermacs--vterm-colorname-to-rgb (name)
   "Convert Emacs color NAME to RGB values."

--- a/aidermacs-backends.el
+++ b/aidermacs-backends.el
@@ -42,11 +42,13 @@ Options are `comint' (the default) or `vterm'.  When set to `vterm',
 aidermacs launches a fully functional vterm buffer instead
 of using a comint process."
   :type '(choice (const :tag "Comint" comint)
-                 (const :tag "VTerm" vterm)))
+                 (const :tag "VTerm" vterm))
+  :group 'aidermacs-backends)
 
 (defcustom aidermacs-output-limit 10
   "Maximum number of output entries to keep in history."
-  :type 'integer)
+  :type 'integer
+  :group 'aidermacs-backends)
 
 (defvar-local aidermacs--output-history nil
   "List to store aidermacs output history.
@@ -60,7 +62,8 @@ Each entry is a cons cell (timestamp . output-text).")
 
 (defcustom aidermacs-before-run-backend-hook nil
   "Hook run before the aidermacs backend is startd."
-  :type 'hook)
+  :type 'hook
+  :group 'aidermacs-backends)
 
 (defun aidermacs-get-output-history (&optional limit)
   "Get the output history, optionally limited to LIMIT entries.

--- a/aidermacs-models.el
+++ b/aidermacs-models.el
@@ -38,20 +38,24 @@
 
 (defcustom aidermacs-default-model "sonnet"
   "Default AI model to use for aidermacs sessions when not in Architect mode."
-  :type 'string)
+  :type 'string
+  :group 'aidermacs-models)
 
 (defcustom aidermacs-architect-model "sonnet"
   "Default AI model to use for architectural reasoning in aidermacs sessions."
-  :type 'string)
+  :type 'string
+  :group 'aidermacs-models)
 
 (defcustom aidermacs-editor-model aidermacs-default-model
   "Default AI model to use for code editing in aidermacs sessions.
 Defaults to `aidermacs-default-model` if not explicitly set."
-  :type 'string)
+  :type 'string
+  :group 'aidermacs-models)
 
 (defcustom aidermacs-use-architect-mode nil
   "If non-nil, use separate Architect/Editor mode."
-  :type 'boolean)
+  :type 'boolean
+  :group 'aidermacs-models)
 
 (defcustom aidermacs-popular-models
   '("sonnet"
@@ -62,7 +66,8 @@ Defaults to `aidermacs-default-model` if not explicitly set."
   "List of available AI models for selection.
 Each model should be in the format expected by the aidermacs CLI.
 Also based on aidermacs LLM benchmark: https://aidermacs.chat/docs/leaderboards/"
-  :type '(repeat string))
+  :type '(repeat string)
+  :group 'aidermacs-models)
 
 (defvar aidermacs--cached-models aidermacs-popular-models
   "Cache of available AI models.")

--- a/aidermacs.el
+++ b/aidermacs.el
@@ -53,11 +53,13 @@ Possible values: `code', `ask', `architect', `help'.")
 (defcustom aidermacs-show-diff-after-change t
   "When non-nil, enable ediff for reviewing AI-generated changes.
 When nil, skip preparing temp buffers and showing ediff comparisons."
-  :type 'boolean)
+  :type 'boolean
+  :group 'aidermacs)
 
 (defcustom aidermacs-program "aider"
   "The name or path of the aidermacs program."
-  :type 'string)
+  :type 'string
+  :group 'aidermacs)
 
 (define-obsolete-variable-alias 'aidermacs-args 'aidermacs-extra-args "0.5.0"
   "Old name for `aidermacs-extra-args', please update your config.")
@@ -67,26 +69,31 @@ When nil, skip preparing temp buffers and showing ediff comparisons."
 When set, Aidermacs will pass this to aider via --config flag,
 ignoring other configuration settings except `aidermacs-extra-args'."
   :type '(choice (const :tag "None" nil)
-                 (file :tag "Config file")))
+                 (file :tag "Config file"))
+  :group 'aidermacs)
 
 (defcustom aidermacs-extra-args '()
   "Additional arguments to pass to the aidermacs command."
-  :type '(repeat string))
+  :type '(repeat string)
+  :group 'aidermacs)
 
 (defcustom aidermacs-subtree-only nil
   "When non-nil, run aider with --subtree-only in the current directory.
 This is useful for working in monorepos where you want to limit aider's scope."
-  :type 'boolean)
+  :type 'boolean
+  :group 'aidermacs)
 
 (defcustom aidermacs-auto-commits nil
   "When non-nil, enable auto-commits of LLM changes.
 When nil, disable auto-commits requiring manual git commits."
-  :type 'boolean)
+  :type 'boolean
+  :group 'aidermacs)
 
 (defcustom aidermacs-auto-accept-architect nil
   "When non-nil, automatically accept architect mode changes.
 When nil, require explicit confirmation before applying changes."
-  :type 'boolean)
+  :type 'boolean
+  :group 'aidermacs)
 
 (defun aidermacs-project-root ()
   "Get the project root using project.el, VC, or fallback to file directory.
@@ -101,7 +108,8 @@ This function tries multiple methods to determine the project root."
 (defcustom aidermacs-prompt-file-name ".aider.prompt.org"
   "File name that will automatically enable `aidermacs-minor-mode' when opened.
 This is the file name without path."
-  :type 'string)
+  :type 'string
+  :group 'aidermacs)
 
 (defconst aidermacs-prompt-regexp "^[^[:space:]<]*>[[:space:]]+$"
   "Regexp to match Aider's command prompt.")
@@ -1158,7 +1166,8 @@ Provides these keybindings:
    ".aider.input.history")
   "List of filenames that should automatically enable `aidermacs-minor-mode'.
 These are exact filename matches (including the dot prefix)."
-  :type '(repeat string))
+  :type '(repeat string)
+  :group 'aidermacs)
 
 (defun aidermacs--maybe-enable-minor-mode ()
   "Determines whether to enable `aidermacs-minor-mode'."


### PR DESCRIPTION
The defcustom calls were missing the :group argument. By adding this we can see all customization options with `M-x customize-group aidermacs`.