### PR TITLE
Don't close vterm buffer on exit; allow troubleshooting

### DIFF
--- a/aidermacs-backend-vterm.el
+++ b/aidermacs-backend-vterm.el
@@ -208,7 +208,8 @@ BUFFER-NAME is the name for the vterm buffer."
   (unless (get-buffer buffer-name)
     (let* ((cmd (mapconcat #'identity (append `(,program ,@(aidermacs--vterm-theme-args)) args) " "))
            (vterm-buffer-name buffer-name)
-           (vterm-shell cmd))
+           (vterm-shell cmd)
+           (vterm-kill-buffer-on-exit nil))
       (with-current-buffer (vterm-other-window)
         (setq-local vterm-max-scrollback 1000
                     aidermacs--vterm-active-timer nil


### PR DESCRIPTION
In certain situations aider can crash or exit immediately, e.g. when passing "--no-auto-accept-architect" but you are still running an older version of aider. 

Vterm by default will kill the buffer, making it impossible to see what went wrong. With this fix we make sure that the window stays open and we can see the error.