### PR TITLE
Improve model configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,18 +152,21 @@ You can switch to it persistently by `M-x aidermacs-switch-to-architect-mode` (`
 
 You can configure each model independently:
 ```emacs-lisp
-;; Architect model for reasoning (defaults to aidermacs-default-model)
+;; Architect model for reasoning (initially defaults to aidermacs-default-model)
 (setq aidermacs-architect-model "sonnet")
 
-;; Editor model for code generation (defaults to aidermacs-default-model)
+;; Editor model for code generation (initially defaults to aidermacs-default-model)
 (setq aidermacs-editor-model "deepseek/deepseek-chat")
 ```
 
 The model hierarchy works as follows:
-- When Architect mode is enabled, `aidermacs-default-model` is ignored
-- The Architect model handles high-level reasoning and solution design
-- The Editor model executes the actual code changes
+- When Architect mode is enabled:
+    - The Architect model handles high-level reasoning and solution design
+    - The Editor model executes the actual code changes
+- When Architect mode is disabled, only `aidermacs-default-model` is used
 - You can configure both models independently or let them default to `aidermacs-default-model`
+
+*Note: The architect and editor models only inherit from `aidermacs-default-model` when first initialized. Changing `aidermacs-default-model` later will not update the other models. For consistent behavior, set each model explicitly.*
 
 *Note: These configurations will be overwritten by the existence of an `.aider.conf.yml` file (see [details](#Overwrite-Configuration-with-Configuration-File)).*
 


### PR DESCRIPTION
Thank you for creating this useful package!

This PR clarifies that `aidermacs-architect-model` and `aidermacs-editor-model` only inherit from `aidermacs-default-model` during initial initialization. Changing `aidermacs-default-model` after package load does not affect these variables.

The current README doesn't seem to make this behavior clear, which leads to unexpected model configuration. I believe this addresses Issue #37, as I experienced the same problem when changing the default model after package initialization.