### PR TITLE
Don't update diff headers in font lock

### DIFF
--- a/aidermacs-backend-comint.el
+++ b/aidermacs-backend-comint.el
@@ -39,6 +39,7 @@
 (declare-function aidermacs--detect-edited-files "aidermacs-output")
 
 (defvar aidermacs--last-command)
+(defvar diff-update-on-the-fly)
 
 (defgroup aidermacs-backend-comint nil
   "Comint backend for Aidermacs."
@@ -193,7 +194,8 @@ _OUTPUT is the text to be processed."
             (with-current-buffer aidermacs--syntax-work-buffer
               (unless (eq mode major-mode)
                 (condition-case e
-                    (let ((inhibit-message t))
+                    (let ((inhibit-message t)
+                          (diff-update-on-the-fly nil))
                       (funcall mode))
                   (error "aidermacs: Failed to init major-mode `%s' for font-locking: %s" mode e))))))
 


### PR DESCRIPTION
fixes #50

The issue here is that diff-mode by default will try and update the line numbers in the headers on the fly. But this leads to the font lock buffer and the actual buffer getting out of sync. For example if it changes from

```diff
@@ -1,36 +1,3 @@
```

to

```diff
@@ -1,9 +1,0 @@
```

The two positions will now be off by 1 (because 36 was changed to 9). To fix we disable this behavior.