### PR TITLE
aidermacs--form-prompt: Always use prompt-prefix and context.

### DIFF
--- a/aidermacs.el
+++ b/aidermacs.el
@@ -597,8 +597,12 @@ Use highlighted region as context unless IGNORE-CONTEXT is set to non-nil."
     ;; Add to history if not already there, removing any duplicates
     (setq aidermacs--read-string-history
           (delete-dups (cons user-command aidermacs--read-string-history)))
-    (concat command (and (not (string-empty-p user-command))
-                         (concat " " prompt-prefix context ": " user-command)))))
+    (concat command
+            " "
+            prompt-prefix
+            context
+            (unless (string-empty-p user-command)
+                (concat ": " user-command)))))
 
 (defun aidermacs-direct-change ()
   "Prompt the user for an input and send it to aidemracs prefixed with \"/code \"."


### PR DESCRIPTION
Currently, user input (user-command) must be non-empty for it to be concatenated with prompt-prefix and context. Otherwise, only the command (e.g., `/code`, `/architecture`...) is sent to aider, effectively doing nothing.

This is confusing when the prompt-prefix is sufficient to form the complete prompt, such as with `aidermacs-write-unit-test`. The user must enter something for the prompt to be formed and sent; otherwise, only `/architect` is sent.

This change simplifies the logic in `aidermacs--form-prompt`. It will always use prompt-prefix and context. If these variables are nil, `concat` will ignore them.