### PR TITLE
Do not require exact matches when selecting models

### DIFF
--- a/aidermacs-models.el
+++ b/aidermacs-models.el
@@ -186,9 +186,9 @@ When SET-WEAK-MODEL is non-nil, only allow setting the weak model."
                 (completing-read
                  "Select model type: "
                  '("Main/Reasoning Model" "Editing Model")
-                 nil t))
+                 nil nil))
                (t "Main Model")))
-             (model (completing-read (format "Select %s: " model-type) aidermacs--cached-models nil t)))
+             (model (completing-read (format "Select %s: " model-type) aidermacs--cached-models nil nil)))
         (when model
           (cond
            (set-weak-model


### PR DESCRIPTION
There are circumstances, e.g. when using ollama, where aider will not give us a correct list of models, instead providing some defaults that nobody uses anymore (llama2 etc). Requiring an exact match in this case blocks users from selecting the model they wish to select.

Ref:
https://github.com/Aider-AI/aider/issues/3081
https://github.com/Aider-AI/aider/pull/3944