### PR TITLE
Use read-from-minibuffer instead of completing-read for prompts

### DIFF
--- a/aidermacs.el
+++ b/aidermacs.el
@@ -587,16 +587,12 @@ Use highlighted region as context unless IGNORE-CONTEXT is set to non-nil."
                         (buffer-substring-no-properties (region-beginning) (region-end))))
          (context (when region-text
                     (format " in %s regarding this section:\n```\n%s\n```\n" (buffer-name) region-text)))
-         ;; Create completion table from common prompts and history
-         (completion-candidates
-          (delete-dups (append aidermacs-common-prompts
-                               aidermacs--read-string-history)))
-         ;; Read user input with completion
-         (user-command (completing-read
-                        (concat command " " prompt-prefix context
-                                (when guide (format " (%s)" guide)) ": ")
-                        completion-candidates nil nil nil
-                        'aidermacs--read-string-history)))
+         ;; Read user input
+         (user-command
+          (read-from-minibuffer
+           (concat command " " prompt-prefix context
+                   (when guide (format " (%s)" guide)) ": ")
+           nil nil nil 'aidermacs--read-string-history)))
     ;; Add to history if not already there, removing any duplicates
     (setq aidermacs--read-string-history
           (delete-dups (cons user-command aidermacs--read-string-history)))


### PR DESCRIPTION
completing-read doesn't let the user enter a prompt that isn't in aidermacs--common-prompts (well, it can, but you sacrifice your ability to use the space key)

A reasonable compromise between making it usable when you don't want to use one of the preselected prompts and still having completion might be pre-populating the history with `aidermacs-common-prompts`, but I've kept it out of this MR.