### PR TITLE
Don't send commands to aider if it's not ready for them

### DIFF
--- a/aidermacs-backend-comint.el
+++ b/aidermacs-backend-comint.el
@@ -124,6 +124,7 @@ are next states.")
     ;; Check if the output contains a prompt
     (when (string-match-p aidermacs-prompt-regexp aidermacs--comint-output-temp)
       (aidermacs--store-output aidermacs--comint-output-temp)
+      (setq-local aidermacs--ready t)
       ;; Check if any files were edited and show ediff if needed
       (let ((edited-files (aidermacs--detect-edited-files)))
         (if edited-files
@@ -316,6 +317,7 @@ BUFFER-NAME is the name for the aidermacs buffer."
     (unless (comint-check-proc buffer-name)
       (apply #'make-comint-in-buffer "aidermacs" buffer-name program nil args)
       (with-current-buffer buffer-name
+        (setq-local aidermacs--ready nil)
         (aidermacs-comint-mode)
         (setq aidermacs--syntax-work-buffer
               (get-buffer-create (concat " *aidermacs-syntax" buffer-name)))))))
@@ -326,6 +328,7 @@ BUFFER is the target buffer.  COMMAND is the text to send."
   (with-current-buffer buffer
     (let ((process (get-buffer-process buffer))
           (inhibit-read-only t))
+      (setq-local aidermacs--ready nil)
       (goto-char (process-mark process))
       (aidermacs-reset-font-lock-state)
       (insert (propertize command

--- a/aidermacs-backend-vterm.el
+++ b/aidermacs-backend-vterm.el
@@ -110,6 +110,7 @@ If the finish sequence is detected, store the output via
             ;; If we found a shell prompt indicating output finished
             (when (string-match-p expected prompt-line)
               (aidermacs--store-output (string-trim output))
+              (setq-local aidermacs--ready t)
               (let ((edited-files (aidermacs--detect-edited-files)))
                 ;; Check if any files were edited and show ediff if needed
                 (if edited-files
@@ -250,7 +251,8 @@ BUFFER-NAME is the name for the vterm buffer."
       (with-current-buffer (vterm-other-window)
         (setq-local vterm-max-scrollback 1000
                     aidermacs--vterm-active-timer nil
-                    aidermacs--vterm-last-check-point nil)
+                    aidermacs--vterm-last-check-point nil
+                    aidermacs--ready t)
         (aidermacs-vterm-mode 1)
         ;; Add cleanup hook
         (add-hook 'kill-buffer-hook #'aidermacs--vterm-cleanup nil t))))
@@ -260,6 +262,7 @@ BUFFER-NAME is the name for the vterm buffer."
   "Send command to the aidermacs vterm buffer.
 BUFFER is the target buffer to send to.  COMMAND is the text to send."
   (with-current-buffer buffer
+    (setq-local aidermacs--ready nil)
     ;; Cancel any existing timer to prevent resource leaks
     (aidermacs--maybe-cancel-active-timer)
     ;; Only process if we have a non-empty command


### PR DESCRIPTION
This can occur when e.g. the autoupdate prompt runs - we send a command, aider is expecting a yes/no, the command doesn't run and comint sometimes throws some error. Instead, ask the user to resolve whatever aider is asking of them first.