### PR TITLE
feat: Ability to configure read-only files

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,20 @@ Aidermacs will take note of all the comments that start or end with `AI`. Commen
 
 *Note: These configurations will be overwritten by the existence of an `.aider.conf.yml` file (see [details](#Overwrite-Configuration-with-Configuration-File)).*
 
+### Read-Only Files
+
+You can configure certain files to always be added as read-only when starting any Aidermacs session by setting the `aidermacs-global-read-only-files` and `aidermacs-project-read-only-files`.
+
+```emacs-lisp
+;; Always add these files as read-only to all Aidermacs sessions
+;; For files that exists outside the project directory
+(setq aidermacs-global-read-only-files '("~/.aider/AI_RULES.md"))
+;; For files that exists within the project directory
+(setq aidermacs-project-read-only-files '("CONVENTIONS.md" "README.md"))
+```
+
+When an Aidermacs session starts, these files will be automatically added as read-only if they exist in the project. This is useful for documentation files or other references that you want the AI to be aware of but not modify.
+
 ### Diff and Change Review
 
 Control whether to show diffs for AI-generated changes with `aidermacs-show-diff-after-change`:

--- a/aidermacs.el
+++ b/aidermacs.el
@@ -77,8 +77,15 @@ ignoring other configuration settings except `aidermacs-extra-args'."
   "Additional arguments to pass to the aidermacs command."
   :type '(repeat string))
 
-(defcustom aidermacs-read-only-files '()
-  "When non-nil, add read-only files to the aidermacs session."
+(defcustom aidermacs-global-read-only-files '()
+  "When non-nil, add read-only files to the aidermacs session. This
+is for files that are set not relative to project
+directory, ie. project agnostic"
+  :type '(repeat string))
+
+(defcustom aidermacs-project-read-only-files '()
+  "When non-nil, add read-only files to the aidermacs session. This
+is for files that exist relative to the project root."
   :type '(repeat string))
 
 (defcustom aidermacs-subtree-only nil
@@ -341,10 +348,15 @@ This function sets up the appropriate arguments and launches the process."
                (list "--weak-model" aidermacs-weak-model))
              (when aidermacs-subtree-only
                '("--subtree-only"))
-             (when aidermacs-read-only-files
+             (when aidermacs-global-read-only-files
                (apply #'append
-                 (mapcar (lambda (file) (list "--read" file))
-                         aidermacs-read-only-files))))))
+                     (mapcar (lambda (file) (list "--read" file))
+                             aidermacs-global-read-only-files)))
+             (when aidermacs-project-read-only-files
+               (apply #'append
+                     (mapcar (lambda (file) (list "--read"
+                                                 (expand-file-name file (aidermacs-project-root))))
+                             aidermacs-project-read-only-files))))))
          ;; Take the original aidermacs-extra-args instead of the flat ones
          (final-args (append backend-args aidermacs-extra-args)))
     (if (aidermacs--live-p buffer-name)
@@ -354,6 +366,7 @@ This function sets up the appropriate arguments and launches the process."
         ;; Set initial mode based on startup configuration
         (setq-local aidermacs--current-mode (if aidermacs-use-architect-mode 'architect 'code)))
       (aidermacs-switch-to-buffer buffer-name))))
+
 
 (defun aidermacs-run-in-current-dir ()
   "Run aidermacs in the current directory with --subtree-only flag.

--- a/aidermacs.el
+++ b/aidermacs.el
@@ -77,6 +77,10 @@ ignoring other configuration settings except `aidermacs-extra-args'."
   "Additional arguments to pass to the aidermacs command."
   :type '(repeat string))
 
+(defcustom aidermacs-read-only-files '()
+  "When non-nil, add read-only files to the aidermacs session."
+  :type '(repeat string))
+
 (defcustom aidermacs-subtree-only nil
   "When non-nil, run aider with --subtree-only in the current directory.
 This is useful for working in monorepos where you want to limit aider's scope."
@@ -336,7 +340,11 @@ This function sets up the appropriate arguments and launches the process."
              (when aidermacs-weak-model
                (list "--weak-model" aidermacs-weak-model))
              (when aidermacs-subtree-only
-               '("--subtree-only")))))
+               '("--subtree-only"))
+             (when aidermacs-read-only-files
+               (apply #'append
+                 (mapcar (lambda (file) (list "--read" file))
+                         aidermacs-read-only-files))))))
          ;; Take the original aidermacs-extra-args instead of the flat ones
          (final-args (append backend-args aidermacs-extra-args)))
     (if (aidermacs--live-p buffer-name)


### PR DESCRIPTION
My suggestion for #129 

I believe this feature is quite important, since it seems to me that the best practice nowadays is to have sets of file defined to provide context, design and commands to the model.