### PR TITLE
Fix temp buffer exec path

### DIFF
--- a/aidermacs.el
+++ b/aidermacs.el
@@ -133,13 +133,15 @@ These will be available for selection when using aidermacs commands."
 Returns a version string like \"0.77.0\" or nil if version can't be determined.
 Uses cached version if available to avoid repeated process calls."
   (interactive)
-  (or aidermacs--cached-version
-      (setq aidermacs--cached-version
-            (with-temp-buffer
-              (when (= 0 (call-process aidermacs-program nil t nil "--version"))
-                (goto-char (point-min))
-                (when (re-search-forward "aider \\([0-9]+\\.[0-9]+\\.[0-9]+\\)" nil t)
-                  (match-string 1))))))
+  (let ((path exec-path))
+    (or aidermacs--cached-version
+        (setq aidermacs--cached-version
+              (with-temp-buffer
+                (setq-local exec-path path)
+                (when (= 0 (call-process aidermacs-program nil t nil "--version"))
+                  (goto-char (point-min))
+                  (when (re-search-forward "aider \\([0-9]+\\.[0-9]+\\.[0-9]+\\)" nil t)
+                    (match-string 1)))))))
   (message "Aider version %s" aidermacs--cached-version)
   aidermacs--cached-version)
 


### PR DESCRIPTION
In a temp buffer, the current `exec-path` is not inherited from the current buffer. This causes problems with packages like
[envrc](https://github.com/purcell/envrc). Currently, if I install aider inside a direnv environment, `aidermacs-aider-version` fails.

This PR fix this by copying the current `exec-path` and setting it inside the temp buffer environment. 

Something like this was done in the rust-mode package: [example pull request](https://github.com/rust-lang/rust-mode/pull/470)

Also, this won't impact other users