### PR TITLE
backends: Adjust the backends for lazy-load vterm

### DIFF
--- a/aidermacs-backends.el
+++ b/aidermacs-backends.el
@@ -21,8 +21,7 @@
 ;;; Code:
 
 (require 'aidermacs-backend-comint)
-(when (commandp 'vterm)
-  (require 'aidermacs-backend-vterm))
+(require 'aidermacs-backend-vterm)
 
 (declare-function aidermacs-run-vterm "aidermacs-backend-vterm")
 (declare-function aidermacs--send-command-vterm "aidermacs-backend-vterm")


### PR DESCRIPTION
Fixes: #135

The detection of whether vterm is present during init or not, before making the functionality to load vterm is somewhat of a chicken-egg. This change allows the vterm backend to be referenced during init. However, loading of the vterm is still on demand based on the users configuration.  Full details are in the GH issue.