### PR TITLE
Fix regexp for vterm-filter-buffer-substring

### DIFF
--- a/aidermacs-backend-vterm.el
+++ b/aidermacs-backend-vterm.el
@@ -160,7 +160,7 @@ Use BUFFER if provided, otherwise retrieve it from `aidermacs-get-buffer-name'."
   "Filter text using ORIG-FUN with ARGS for cleaner vterm display.
 Converts multiple spaces to newlines and trims trailing whitespace."
   (let* ((text (apply orig-fun args))
-         (space-fixed (replace-regexp-in-string "[ \t]{3,}" "\n" text))
+         (space-fixed (replace-regexp-in-string "[ \t]\\{3\\}" "\n" text))
          (lines (split-string space-fixed "\n"))
          (clean-lines (mapcar #'string-trim-right lines))
          (fixed-text (string-join clean-lines "\n")))


### PR DESCRIPTION
The repetition regexp `\{3\}` needs a escape backslashes in Emacs: https://www.gnu.org/software/emacs/manual/html_node/emacs/Regexp-Backslash.html.

And when writing the regexp as a string, you need to double the backslashes: https://stackoverflow.com/questions/538842/emacs-regular-expressions-in-lisp-need-to-be-double-escaped-why

Also see my comment on issue #68, which in my experience was wrongly closed: https://github.com/MatthewZMD/aidermacs/issues/68#issuecomment-3078883191