### PR TITLE
Make a copy of process-environment to prevent leaking secrets set in hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Example usage to securely set an OpenAI API key from password-store:
             (setenv "OPENAI_API_KEY" (password-store-get "code/openai_api_key"))))
 ```
 
-This approach keeps sensitive information out of your dotfiles while still making it available to Aidermacs.
+The environment variable set in the hook would only be visible to aider process. This approach keeps sensitive information out of your dotfiles while still making it available to Aidermacs.
 
 ### Default Model Selection
 

--- a/aidermacs-backends.el
+++ b/aidermacs-backends.el
@@ -60,12 +60,14 @@ of using a comint process."
 PROGRAM is the aidermacs executable path.  ARGS are command line arguments.
 BUFFER-NAME is the name for the aidermacs buffer."
   (message "Running %s with %s" program args)
-  (run-hooks 'aidermacs-before-run-backend-hook)
-  (cond
-   ((eq aidermacs-backend 'vterm)
-    (aidermacs-run-vterm program args buffer-name))
-   (t
-    (aidermacs-run-comint program args buffer-name))))
+  ;; make a copy of process-environment, so that secrets set in the hook is only visible by aider
+  (let ((process-environment process-environment))
+    (run-hooks 'aidermacs-before-run-backend-hook)
+    (cond
+     ((eq aidermacs-backend 'vterm)
+      (aidermacs-run-vterm program args buffer-name))
+     (t
+      (aidermacs-run-comint program args buffer-name)))))
 
 (defun aidermacs--is-aidermacs-buffer-p (&optional buffer)
   "Check if BUFFER is any type of aidermacs buffer.


### PR DESCRIPTION
before this change, the environment would be visible in all other processes emacs launches in the future