### PR TITLE
Set default extra-args to skip update checking and release notes

### DIFF
--- a/aidermacs.el
+++ b/aidermacs.el
@@ -94,7 +94,7 @@ ignoring other configuration settings except `aidermacs-extra-args'."
 (define-obsolete-variable-alias 'aidermacs-args 'aidermacs-extra-args "0.5.0"
   "Old name for `aidermacs-extra-args', please update your config.")
 
-(defcustom aidermacs-extra-args '()
+(defcustom aidermacs-extra-args '("--no-check-update" "--no-show-release-notes")
   "Additional arguments to pass to the aidermacs command."
   :type '(repeat string))
 


### PR DESCRIPTION
this one is a little bit opinionated.. personally I think it makes sense to skip these possible interruption during startup, to prevent aidermacs failing to send commands to the backend