### PR TITLE
Fix aider version check

### DIFF
--- a/aidermacs.el
+++ b/aidermacs.el
@@ -175,8 +175,8 @@ Uses cached version if available to avoid repeated process calls."
                 (when (= 0 (process-file aidermacs-program nil t nil "--version"))
                   (goto-char (point-min))
                   (when (re-search-forward
-                         (concat aidermacs-program " \\([0-9]+\\.[0-9]+\\.[0-9]+\\)") nil t)
-                    (match-string 1)))))))
+                         "\\([0-9]+\\.[0-9]+\\.[0-9]+\\)" nil t)
+                    (match-string 0)))))))
   (message "Aider version %s" aidermacs--cached-version)
   aidermacs--cached-version)
 


### PR DESCRIPTION
The current version check fails when the `aidermacs-program` variable is set to the full path of the aider executable, or when the user renames the executable. To resolve this, it's sufficient to skip concatenating `aidermacs-program` into the regex string.