### PR TITLE
Improve prompt detection & notifications

### DIFF
--- a/aidermacs-backend-comint.el
+++ b/aidermacs-backend-comint.el
@@ -27,6 +27,7 @@
 (require 'cl-lib)
 (require 'map)
 (require 'markdown-mode)
+(require 'ansi-color)
 
 ;; Forward declarations
 (declare-function aidermacs--prepare-for-code-edit "aidermacs-output")
@@ -38,6 +39,7 @@
 (declare-function aidermacs--show-ediff-for-edited-files "aidermacs-output")
 (declare-function aidermacs--cleanup-temp-buffers "aidermacs-output")
 (declare-function aidermacs--detect-edited-files "aidermacs-output")
+(declare-function aidermacs--send-notification "aidermacs")
 
 (defvar aidermacs--last-command)
 (defvar diff-update-on-the-fly)
@@ -116,22 +118,40 @@ are next states.")
   "Temporary output variable storing the raw output string.")
 
 (defvar aidermacs-prompt-regexp)
+(defvar aidermacs-question-regexp)
 
 (defun aidermacs--comint-output-filter (output)
   "Accumulate OUTPUT string until a prompt is detected, then store it."
   (when (and (aidermacs--is-aidermacs-buffer-p) (not (string-empty-p output)))
+    ;; Filter ANSI escape sequences before accumulating to ensure regex matching works
     (setq aidermacs--comint-output-temp
-          (concat aidermacs--comint-output-temp (substring-no-properties output)))
-    ;; Check if the output contains a prompt
-    (when (string-match-p aidermacs-prompt-regexp aidermacs--comint-output-temp)
-      (aidermacs--store-output aidermacs--comint-output-temp)
-      (setq-local aidermacs--ready t)
-      ;; Check if any files were edited and show ediff if needed
-      (let ((edited-files (aidermacs--detect-edited-files)))
-        (if edited-files
-            (aidermacs--show-ediff-for-edited-files edited-files)
-          (aidermacs--cleanup-temp-buffers)))
-      (setq aidermacs--comint-output-temp ""))))
+          (concat aidermacs--comint-output-temp
+                  (ansi-color-filter-apply (substring-no-properties output))))
+
+    ;; Check for standard prompt or question prompt
+    (let ((has-prompt (string-match-p aidermacs-prompt-regexp aidermacs--comint-output-temp))
+          (has-question (string-match-p aidermacs-question-regexp aidermacs--comint-output-temp)))
+
+      (if (or has-prompt has-question)
+          ;; Prompt detected: aider is waiting, check notification and reset timer
+          (progn
+            ;; Check if we need to send notification
+            (when aidermacs--command-start-time
+              (let ((elapsed (float-time (time-subtract (current-time) aidermacs--command-start-time))))
+                (when (> elapsed aidermacs-notify-after-seconds)
+                  (aidermacs--send-notification "Aidermacs" "Aider needs your attention"))))
+            ;; Always reset timer when prompt is detected
+            (setq aidermacs--command-start-time nil)
+            (aidermacs--store-output aidermacs--comint-output-temp)
+            (setq-local aidermacs--ready t)
+            ;; Check if any files were edited and show ediff if needed
+            (let ((edited-files (aidermacs--detect-edited-files)))
+              (if edited-files
+                  (aidermacs--show-ediff-for-edited-files edited-files)
+                (aidermacs--cleanup-temp-buffers)))
+            (setq aidermacs--comint-output-temp ""))
+        ;; No prompt detected: aider is still outputting
+        ))))
 
 (defun aidermacs-reset-font-lock-state ()
   "Reset font lock state to default for processing a new source block."
@@ -305,11 +325,13 @@ PROC is the process to send to.  STRING is the command to send."
   (aidermacs-reset-font-lock-state)
   ;; Store the command for tracking in the correct buffer
   (with-current-buffer (process-buffer proc)
-    (if (member (downcase string) '("" "y" "n" "d" "yes" "no"))
-        (aidermacs--parse-output-for-files aidermacs--comint-output-temp)
-      (setq aidermacs--last-command string)
-      (when (aidermacs--command-may-edit-files string)
-        (aidermacs--prepare-for-code-edit))))
+    ;; Always set timestamp for any input, including y/n/yes/no
+    (setq-local aidermacs--last-command string)
+    (setq-local aidermacs--command-start-time (current-time))
+    (when (member (downcase string) '("" "y" "n" "d" "yes" "no" "a" "s"))
+      (aidermacs--parse-output-for-files aidermacs--comint-output-temp))
+    (when (aidermacs--command-may-edit-files string)
+      (aidermacs--prepare-for-code-edit)))
   (comint-simple-send proc (aidermacs--process-message-if-multi-line string)))
 
 (defun aidermacs-run-comint (program args buffer-name)
@@ -366,6 +388,12 @@ The output is collected and passed to the current callback."
   (interactive)
   (comint-interrupt-subjob)
   (when (aidermacs--is-aidermacs-buffer-p)
+    ;; Reset command state
+    (setq-local aidermacs--ready t)
+    (setq-local aidermacs--command-start-time nil)
+    (setq-local aidermacs--last-command nil)
+    (setq-local aidermacs--current-callback nil)
+    ;; Clean up temp buffers
     (aidermacs--cleanup-temp-buffers)))
 
 (defvar aidermacs-comint-mode-map

--- a/aidermacs-backend-comint.el
+++ b/aidermacs-backend-comint.el
@@ -41,6 +41,9 @@
 (declare-function aidermacs--detect-edited-files "aidermacs-output")
 (declare-function aidermacs--send-notification "aidermacs")
 
+(defvar aidermacs--command-start-time)
+(defvar aidermacs-notify-after-seconds)
+
 (defvar aidermacs--last-command)
 (defvar diff-update-on-the-fly)
 

--- a/aidermacs-backend-vterm.el
+++ b/aidermacs-backend-vterm.el
@@ -49,6 +49,9 @@
 (declare-function aidermacs--cleanup-temp-buffers "aidermacs-output")
 (declare-function aidermacs--send-notification "aidermacs")
 
+(defvar aidermacs--command-start-time)
+(defvar aidermacs-notify-after-seconds)
+
 (declare-function evil-define-minor-mode-key "evil-core")
 
 (defvar aidermacs-prompt-regexp)

--- a/aidermacs-backend-vterm.el
+++ b/aidermacs-backend-vterm.el
@@ -47,10 +47,12 @@
 (declare-function aidermacs--parse-output-for-files "aidermacs-output")
 (declare-function aidermacs--show-ediff-for-edited-files "aidermacs-output")
 (declare-function aidermacs--cleanup-temp-buffers "aidermacs-output")
+(declare-function aidermacs--send-notification "aidermacs")
 
 (declare-function evil-define-minor-mode-key "evil-core")
 
 (defvar aidermacs-prompt-regexp)
+(defvar aidermacs-question-regexp)
 (defvar aidermacs--last-command)
 
 (defgroup aidermacs-backend-vterm nil
@@ -89,11 +91,10 @@ If the finish sequence is detected, store the output via
                              (error (point-max))))
              ;; Only check if we have a new prompt or haven't checked this position yet
              (last-check (or aidermacs--vterm-last-check-point start-point))
-             (should-check (> prompt-point last-check))
+             (should-check (or (> prompt-point last-check)
+                               (> (point-max) last-check)))
              ;; Pattern that looks for a shell prompt
              (expected aidermacs-prompt-regexp))
-        ;; Update the last check point
-        (setq aidermacs--vterm-last-check-point prompt-point)
         (when should-check
           (let* ((seq-start (or (save-excursion
                                   (goto-char prompt-point)
@@ -104,22 +105,35 @@ If the finish sequence is detected, store the output via
                  ;; Only get the prompt line, not the whole sequence (limit to 200 chars)
                  (prompt-line-end (min (+ seq-start 200) (point-max)))
                  (prompt-line (buffer-substring-no-properties seq-start prompt-line-end))
-                 (output (buffer-substring-no-properties start-point seq-start)))
+                 (output (buffer-substring-no-properties start-point seq-start))
+                 (recent-output (buffer-substring-no-properties last-check (point-max))))
             ;; Parse output for files
             (aidermacs--parse-output-for-files output)
-            ;; If we found a shell prompt indicating output finished
-            (when (string-match-p expected prompt-line)
-              (aidermacs--store-output (string-trim output))
-              (setq-local aidermacs--ready t)
-              (let ((edited-files (aidermacs--detect-edited-files)))
-                ;; Check if any files were edited and show ediff if needed
-                (if edited-files
-                    (aidermacs--show-ediff-for-edited-files edited-files)
-                  (aidermacs--cleanup-temp-buffers))
-                ;; Restore the original process filter now that we've finished processing
-                ;; this command's output. This returns vterm to its normal behavior.
-                (set-process-filter proc orig-filter)
-                (aidermacs--maybe-cancel-active-timer (process-buffer proc))))))))))
+            ;; Check for standard prompt or question prompt
+            (let ((has-prompt (string-match-p expected prompt-line))
+                  (has-question (string-match-p aidermacs-question-regexp recent-output)))
+              (when has-question
+                (when aidermacs--command-start-time
+                  (let ((elapsed (float-time (time-subtract (current-time) aidermacs--command-start-time))))
+                    (when (> elapsed aidermacs-notify-after-seconds)
+                      (aidermacs--send-notification "Aidermacs" "Aider needs your attention"))))
+                (setq-local aidermacs--ready t))
+              (if has-prompt
+                  (progn
+                    (when aidermacs--command-start-time
+                      (let ((elapsed (float-time (time-subtract (current-time) aidermacs--command-start-time))))
+                        (when (> elapsed aidermacs-notify-after-seconds)
+                          (aidermacs--send-notification "Aidermacs" "Aider needs your attention"))))
+                    (setq aidermacs--command-start-time nil)
+                    (aidermacs--store-output (string-trim output))
+                    (setq-local aidermacs--ready t)
+                    (let ((edited-files (aidermacs--detect-edited-files)))
+                      (if edited-files
+                          (aidermacs--show-ediff-for-edited-files edited-files)
+                        (aidermacs--cleanup-temp-buffers)))
+                    (set-process-filter proc orig-filter)
+                    (aidermacs--maybe-cancel-active-timer (process-buffer proc)))
+                (setq aidermacs--vterm-last-check-point (point-max))))))))))
 
 (defun aidermacs--vterm-capture-output ()
   "Capture vterm output until the finish sequence appears.
@@ -305,6 +319,7 @@ BUFFER is the target buffer to send to.  COMMAND is the text to send."
                        (line-end-position))))
         (when (not (string-empty-p command))
           (setq-local aidermacs--last-command command)
+          (setq-local aidermacs--command-start-time (current-time))
           (when (aidermacs--command-may-edit-files command)
             (aidermacs--prepare-for-code-edit)))))))
 
@@ -319,6 +334,12 @@ _ARGS are the arguments."
   (when (aidermacs--is-aidermacs-buffer-p)
     ;; Cancel any active timer
     (aidermacs--maybe-cancel-active-timer)
+    ;; Reset command state
+    (setq-local aidermacs--ready t)
+    (setq-local aidermacs--command-start-time nil)
+    (setq-local aidermacs--last-command nil)
+    (setq-local aidermacs--current-callback nil)
+    ;; Clean up temp buffers
     (aidermacs--cleanup-temp-buffers)))
 
 (defvar aidermacs-vterm-mode-map

--- a/aidermacs-backends.el
+++ b/aidermacs-backends.el
@@ -54,6 +54,32 @@ of using a comint process."
 (defconst aidermacs-prompt-regexp "^[^[:space:]<]*>[[:space:]]+$"
   "Regexp to match Aider's command prompt.")
 
+(defvar aidermacs-question-regexp "(Y)es/(N)o"
+  "Regexp to detect aider Y/N confirmation prompts.
+Matches all confirmation prompts including:
+- Edit the files? (Y)es/(N)o [Yes]:
+- Attempt to fix lint errors? (Y)es/(N)o [Yes]:
+- Add file to the chat? (Y)es/(N)o/(D)on't ask again [Yes]:
+- Add file to the chat? (Y)es/(N)o/(A)ll/(S)kip all/(D)on't ask again [Yes]:
+- Add URL to the chat? (Y)es/(N)o/(D)on't ask again [Yes]:
+- Add URL to the chat? (Y)es/(N)o/(A)ll/(S)kip all/(D)on't ask again [Yes]:
+The (Y)es/(N)o pattern is the common denominator across all variants.
+
+Limitations of this permissive regexp:
+1. False positives: Any text containing \"(Y)es/(N)o\" will be treated as a prompt,
+   potentially triggering notifications prematurely. This includes:
+   - User messages discussing confirmation prompts
+   - AI responses containing the pattern as example text
+   - Code snippets or documentation mentioning the pattern
+2. False positive probability: Moderate. The pattern is specific enough to avoid
+   most casual text, but technical discussions about aider's prompts may trigger it.
+   In normal usage, false positives are infrequent but possible.
+3. No context awareness: The regexp doesn't check if the pattern appears at the
+   end of a line (where prompts usually are) or is followed by \" [Yes]:\".
+   This increases recall but reduces precision.
+4. Timing implications: Premature detection may cause notifications to be sent
+   before the user has actually seen the prompt, reducing their usefulness.")
+
 ;; Backend dispatcher functions
 (defun aidermacs-run-backend (program args buffer-name)
   "Run aidermacs using the selected backend.

--- a/aidermacs.el
+++ b/aidermacs.el
@@ -42,6 +42,7 @@
 (require 'aidermacs-output)
 
 (declare-function magit-show-commit "magit-diff")
+(declare-function notifications-notify "notifications")
 
 (defgroup aidermacs nil
   "AI pair programming with Aider."

--- a/aidermacs.el
+++ b/aidermacs.el
@@ -58,6 +58,21 @@ If it is a list, Aidermacs will try each program in order."
 (defvar aidermacs--cached-versions (make-hash-table :test 'equal)
   "Hash table of cached aider versions keyed by workspace.")
 
+(defcustom aidermacs-enable-notifications t
+  "When non-nil, send system notification when aider command completes.
+This is useful when aider takes a long time to process and the user
+has switched to another application."
+  :type 'boolean)
+
+(defcustom aidermacs-notify-after-seconds 120
+  "Minimum seconds elapsed before sending notification on command completion.
+Only applies when `aidermacs-enable-notifications' is non-nil."
+  :type 'integer)
+
+(defvar-local aidermacs--command-start-time nil
+  "Timestamp when the current command was sent to aider.
+Used to determine if notification should be sent when command completes.")
+
 (defun aidermacs--get-cache-key ()
   "Generate a unique cache key based on current workspace context.
 Returns a string combining the remote connection (if any) and project root."
@@ -228,6 +243,60 @@ Call this after upgrading aider to ensure the correct version is detected."
         (message "Aider version cache cleared for all workspaces."))
     (remhash (aidermacs--get-cache-key) aidermacs--cached-versions)
     (message "Aider version cache cleared for current workspace.")))
+
+(defun aidermacs--send-notification (title message)
+  "Send system notification with TITLE and MESSAGE.
+Uses `notifications' library if available, otherwise falls back to
+system-specific commands."
+  (when aidermacs-enable-notifications
+    (condition-case err
+        (cond
+         ((featurep 'notifications)
+          (notifications-notify
+           :title title
+           :body message
+           :app-name "Aidermacs"
+           :timeout 0))
+         ((eq system-type 'darwin)
+          (cond
+           ((executable-find "alerter")
+            (make-process
+             :name "aidermacs-alerter"
+             :command (list "alerter"
+                            "--title" title
+                            "--message" message
+                            "--sound" "default"
+                            "--timeout" "0")
+             :noquery t
+             :connection-type 'pipe))
+           ((executable-find "terminal-notifier")
+            (make-process
+             :name "aidermacs-terminal-notifier"
+             :command (list "terminal-notifier"
+                           "-title" title
+                           "-message" message
+                           "-sound" "default"
+                           "-activate" "org.gnu.Emacs"
+                           "-timeout" "0")
+             :noquery t
+             :connection-type 'pipe))
+           (t
+            (call-process "osascript" nil nil nil
+                          "-e" (format "display notification \"%s\" with title \"%s\" sound name \"default\""
+                                      message title)))))
+         ((eq system-type 'gnu/linux)
+          (call-process "notify-send" nil nil nil
+                       title message
+                       "-t" "0"))
+         ((eq system-type 'windows-nt)
+          (call-process "powershell" nil nil nil
+                       "-Command"
+                       (format "[System.Reflection.Assembly]::LoadWithPartialName('System.Windows.Forms'); [System.Windows.Forms.MessageBox]::Show('%s', '%s', [System.Windows.Forms.MessageBoxButtons]::OK, [System.Windows.Forms.MessageBoxIcon]::Information)"
+                               message title)))
+         (t
+          nil))
+      (error
+       (message "Failed to send notification: %s" err)))))
 
 (defun aidermacs-project-root ()
   "Get the project root using VC-git, or fallback to file directory.


### PR DESCRIPTION
- Add ANSI color support via `ansi-color` library
- Implement question prompt detection for confirmation prompts
- Add configurable notification system:
  • Customizable notification threshold (120s default)
  • Cross-platform notification support
  • Fallback mechanisms for unsupported systems
- Update regex patterns for both standard prompts and confirmation prompts
- Add command tracking with timestamps for notification timing