### PR TITLE
Add command output analysis confirmation handling

### DIFF
--- a/aidermacs-backend-comint.el
+++ b/aidermacs-backend-comint.el
@@ -120,6 +120,9 @@ are next states.")
 (defvar-local aidermacs--comint-output-temp ""
   "Temporary output variable storing the raw output string.")
 
+(defvar-local aidermacs--comint-awaiting-output-analysis nil
+  "Non-nil when aider asked to add command output and user confirmed.")
+
 (defvar aidermacs-prompt-regexp)
 (defvar aidermacs-question-regexp)
 
@@ -135,6 +138,11 @@ are next states.")
     (let ((has-prompt (string-match-p aidermacs-prompt-regexp aidermacs--comint-output-temp))
           (has-question (string-match-p aidermacs-question-regexp aidermacs--comint-output-temp)))
 
+      ;; Detect specific question types
+      (when has-question
+        (setq-local aidermacs--comint-awaiting-output-analysis
+                    (string-match-p "Add command output to the chat" aidermacs--comint-output-temp)))
+
       (if (or has-prompt has-question)
           ;; Prompt detected: aider is waiting, check notification and reset timer
           (progn
@@ -145,6 +153,12 @@ are next states.")
                   (aidermacs--send-notification "Aidermacs" "Aider needs your attention"))))
             ;; Always reset timer when prompt is detected
             (setq aidermacs--command-start-time nil)
+            ;; If user confirmed adding command output, trigger analysis now that aider is back at prompt
+            (when (and has-prompt aidermacs--comint-awaiting-output-analysis)
+              (setq-local aidermacs--comint-awaiting-output-analysis nil)
+              (let ((proc (get-buffer-process (current-buffer))))
+                (when (and proc (process-live-p proc))
+                  (process-send-string proc "Please analyze the command output above.\n"))))
             (aidermacs--store-output aidermacs--comint-output-temp)
             (setq-local aidermacs--ready t)
             ;; Check if any files were edited and show ediff if needed
@@ -152,7 +166,10 @@ are next states.")
               (if edited-files
                   (aidermacs--show-ediff-for-edited-files edited-files)
                 (aidermacs--cleanup-temp-buffers)))
-            (setq aidermacs--comint-output-temp ""))
+            (setq aidermacs--comint-output-temp "")
+            ;; Reset flag on normal prompt if not already cleared
+            (unless has-question
+              (setq-local aidermacs--comint-awaiting-output-analysis nil)))
         ;; No prompt detected: aider is still outputting
         ))))
 
@@ -332,6 +349,9 @@ PROC is the process to send to.  STRING is the command to send."
     (setq-local aidermacs--last-command string)
     (setq-local aidermacs--command-start-time (current-time))
     (when (member (downcase string) '("" "y" "n" "d" "yes" "no" "a" "s"))
+      ;; User declined: clear flag immediately to prevent false trigger
+      (unless (member (downcase string) '("" "y" "yes" "a"))
+        (setq-local aidermacs--comint-awaiting-output-analysis nil))
       (aidermacs--parse-output-for-files aidermacs--comint-output-temp))
     (when (aidermacs--command-may-edit-files string)
       (aidermacs--prepare-for-code-edit)))

--- a/aidermacs-backend-vterm.el
+++ b/aidermacs-backend-vterm.el
@@ -68,6 +68,9 @@
 (defvar-local aidermacs--vterm-last-check-point nil
   "Store the last position checked in the vterm buffer.")
 
+(defvar-local aidermacs--vterm-awaiting-output-analysis nil
+  "Non-nil when aider asked to add command output and user confirmed.")
+
 (defvar-local aidermacs-vterm-check-interval 0.7
   "Interval in seconds between checks for command completion in vterm.")
 
@@ -115,7 +118,10 @@ If the finish sequence is detected, store the output via
             ;; Check for standard prompt or question prompt
             (let ((has-prompt (string-match-p expected prompt-line))
                   (has-question (string-match-p aidermacs-question-regexp recent-output)))
+              ;; Detect specific question types
               (when has-question
+                (setq-local aidermacs--vterm-awaiting-output-analysis
+                            (string-match-p "Add command output to the chat" recent-output))
                 (when aidermacs--command-start-time
                   (let ((elapsed (float-time (time-subtract (current-time) aidermacs--command-start-time))))
                     (when (> elapsed aidermacs-notify-after-seconds)
@@ -128,12 +134,20 @@ If the finish sequence is detected, store the output via
                         (when (> elapsed aidermacs-notify-after-seconds)
                           (aidermacs--send-notification "Aidermacs" "Aider needs your attention"))))
                     (setq aidermacs--command-start-time nil)
+                    ;; Trigger analysis if user confirmed adding command output
+                    (when aidermacs--vterm-awaiting-output-analysis
+                      (setq-local aidermacs--vterm-awaiting-output-analysis nil)
+                      (vterm-send-string "Please analyze the command output above.")
+                      (vterm-send-return))
                     (aidermacs--store-output (string-trim output))
                     (setq-local aidermacs--ready t)
                     (let ((edited-files (aidermacs--detect-edited-files)))
                       (if edited-files
                           (aidermacs--show-ediff-for-edited-files edited-files)
                         (aidermacs--cleanup-temp-buffers)))
+                    ;; Reset flag on normal prompt if not already cleared
+                    (unless has-question
+                      (setq-local aidermacs--vterm-awaiting-output-analysis nil))
                     (set-process-filter proc orig-filter)
                     (aidermacs--maybe-cancel-active-timer (process-buffer proc)))
                 (setq aidermacs--vterm-last-check-point (point-max))))))))))
@@ -294,6 +308,17 @@ BUFFER is the target buffer to send to.  COMMAND is the text to send."
   "Send return to the aidermacs vterm buffer, and process the output."
   (interactive)
   (aidermacs--vterm-capture-keyboard-input)
+  ;; Handle confirmation replies for command output analysis
+  (let* ((prompt-point (condition-case nil
+                           (vterm--get-prompt-point)
+                         (error (point-min))))
+         (cmd (string-trim (buffer-substring-no-properties
+                            prompt-point
+                            (line-end-position)))))
+    (when (member (downcase cmd) '("" "y" "n" "d" "yes" "no" "a" "s"))
+      ;; User declined: clear flag immediately to prevent false trigger
+      (unless (member (downcase cmd) '("" "y" "yes" "a"))
+        (setq-local aidermacs--vterm-awaiting-output-analysis nil))))
   (aidermacs--vterm-capture-output)
   (vterm-send-return))
 


### PR DESCRIPTION
- Track when aider asks to add command output to chat
- Automatically trigger analysis after user confirms (y/yes/a)
- Clear analysis flag when user declines (n/no/s)
- Implement for both comint and vterm backends
- Reset flags properly on normal prompts
- Send analysis request to aider process after confirmation