### PR TITLE
Add model filtering and configured model support

### DIFF
--- a/aidermacs-backend-comint.el
+++ b/aidermacs-backend-comint.el
@@ -190,14 +190,15 @@ are next states.")
         aidermacs--syntax-last-output-pos nil))
 
 (defun aidermacs--set-syntax-major-mode ()
-(let ((mode (aidermacs--guess-major-mode)))
-  (with-current-buffer aidermacs--syntax-work-buffer
-    (unless (eq mode major-mode)
-      (condition-case e
-          (let ((inhibit-message t)
-                (diff-update-on-the-fly nil))
-            (funcall mode))
-        (error "aidermacs: Failed to init major-mode `%s' for font-locking: %s" mode e))))))
+  "Set the major mode of the syntax work buffer to match the current block."
+  (let ((mode (aidermacs--guess-major-mode)))
+    (with-current-buffer aidermacs--syntax-work-buffer
+      (unless (eq mode major-mode)
+        (condition-case e
+            (let ((inhibit-message t)
+                  (diff-update-on-the-fly nil))
+              (funcall mode))
+          (error "aidermacs: Failed to init major-mode `%s' for font-locking: %s" mode e))))))
 
 (defun aidermacs-fontify-blocks (_output)
   "Fontify search/replace blocks in comint output.

--- a/aidermacs-backends.el
+++ b/aidermacs-backends.el
@@ -66,13 +66,14 @@ Matches all confirmation prompts including:
 The (Y)es/(N)o pattern is the common denominator across all variants.
 
 Limitations of this permissive regexp:
-1. False positives: Any text containing \"(Y)es/(N)o\" will be treated as a prompt,
-   potentially triggering notifications prematurely. This includes:
+1. False positives: Any text containing \"(Y)es/(N)o\" will be treated as a
+   prompt, potentially triggering notifications prematurely. This includes:
    - User messages discussing confirmation prompts
    - AI responses containing the pattern as example text
    - Code snippets or documentation mentioning the pattern
 2. False positive probability: Moderate. The pattern is specific enough to avoid
-   most casual text, but technical discussions about aider's prompts may trigger it.
+   most casual text, but technical discussions about aider's prompts may
+   trigger it.
    In normal usage, false positives are infrequent but possible.
 3. No context awareness: The regexp doesn't check if the pattern appears at the
    end of a line (where prompts usually are) or is followed by \" [Yes]:\".

--- a/aidermacs-models.el
+++ b/aidermacs-models.el
@@ -31,6 +31,7 @@
 (declare-function aidermacs-exit "aidermacs")
 (declare-function aidermacs-aider-version "aidermacs")
 (declare-function aidermacs-get-buffer-name "aidermacs")
+(declare-function aidermacs-project-root "aidermacs")
 
 (defvar aidermacs--current-output)
 (defvar aidermacs-use-architect-mode)
@@ -70,7 +71,8 @@ Respects the `AIDER_WEAK_MODEL' environment variable if set."
 (defcustom aidermacs-litellm-prices-file nil
   "Manual path to litellm model_prices_and_context_window.json.
 If set, use this path directly instead of searching.
-Example: \"~/.local/lib/python3.11/site-packages/litellm/model_prices_and_context_window.json\""
+Example: \"~/.local/lib/python3.11/site-packages/litellm/\
+model_prices_and_context_window.json\""
   :type '(choice (const :tag "Auto-detect" nil)
                  (file :tag "Specify path"))
   :group 'aidermacs-models)
@@ -91,7 +93,8 @@ Example: \"~/.local/lib/python3.11/site-packages/litellm/model_prices_and_contex
   :group 'aidermacs-models)
 
 (defvar aidermacs--litellm-prices-cache nil
-  "Cache of litellm model prices. Alist mapping model-id to ((input-price . val) (output-price . val)).")
+  "Cache of litellm model prices.
+Alist mapping model-id to ((input-price . val) (output-price . val)).")
 
 (defvar aidermacs--litellm-prices-cache-timestamp nil
   "Timestamp when litellm prices were last fetched.")
@@ -280,7 +283,7 @@ Returns a list (exact-hash family-hash provider-family-hash)."
     (list exact family prov-fam)))
 
 (defun aidermacs--match-model-price-fast (model-id index)
-  "Fast price lookup using prebuilt INDEX."
+  "Fast price lookup for MODEL-ID using prebuilt INDEX."
   (when index
     (let* ((identity (aidermacs--parse-model-identity model-id))
            (exact (nth 0 index))
@@ -351,7 +354,8 @@ Returns a list of (model . rank) cons cells, where rank starts from 1."
 
 (defun aidermacs--make-model-annotator (cheapest-models configured-models)
   "Create annotation function for the cheapest models.
-CHEAPEST-MODELS is a list of (model . rank) from `aidermacs--get-cheapest-models'.
+CHEAPEST-MODELS is a list of (model . rank) from
+`aidermacs--get-cheapest-models'.
 CONFIGURED-MODELS is a list of model IDs that are user-configured."
   (let ((rank-map (make-hash-table :test 'equal))
         (configured-set (make-hash-table :test 'equal)))
@@ -465,8 +469,10 @@ When SET-WEAK-MODEL is non-nil, only allow setting the weak model."
   "Parse MODEL-ID into canonical identity components.
 Returns an alist with keys: provider, family, variant, full-id.
 Examples:
-  \"openai/gpt-4o-2024-08-06\" -> ((provider . \"openai\") (family . \"gpt-4o\") ...)
-  \"claude-3-5-sonnet-20241022\" -> ((provider . nil) (family . \"claude-3-5-sonnet\") ...)"
+  \"openai/gpt-4o-2024-08-06\" ->
+    ((provider . \"openai\") (family . \"gpt-4o\") ...)
+  \"claude-3-5-sonnet-20241022\" ->
+    ((provider . nil) (family . \"claude-3-5-sonnet\") ...)"
   (unless (stringp model-id)
     (message "Warning: model-id is not a string: %S (type: %s)" model-id (type-of model-id))
     (setq model-id (format "%s" model-id)))

--- a/aidermacs-models.el
+++ b/aidermacs-models.el
@@ -80,6 +80,16 @@ Example: \"~/.local/lib/python3.11/site-packages/litellm/model_prices_and_contex
   :type 'integer
   :group 'aidermacs-models)
 
+(defcustom aidermacs-model-filter-mode 'all
+  "How to filter models in the selection list.
+- `configured-only': Only show models from the model settings file
+- `configured-first': Show configured models first, then all others
+- `all': Show all models (no filtering)"
+  :type '(choice (const :tag "Only configured models" configured-only)
+                 (const :tag "Configured models first" configured-first)
+                 (const :tag "All models" all))
+  :group 'aidermacs-models)
+
 (defvar aidermacs--litellm-prices-cache nil
   "Cache of litellm model prices. Alist mapping model-id to ((input-price . val) (output-price . val)).")
 
@@ -88,6 +98,45 @@ Example: \"~/.local/lib/python3.11/site-packages/litellm/model_prices_and_contex
 
 (defvar aidermacs--litellm-file-path-cache nil
   "Cache of the litellm prices file path.")
+
+(defun aidermacs--find-model-settings-file ()
+  "Find the aider model settings YAML file.
+Searches in order: env var, homedir, git root, cwd.
+Default filename is `.aider.model.settings.yml' (matching aider's behavior)."
+  (or (getenv "AIDER_MODEL_SETTINGS_FILE")
+      (let* ((default-file ".aider.model.settings.yml")
+             (patterns
+              (list
+               (expand-file-name (concat "~/" default-file))  ; homedir
+               (when-let ((root (aidermacs-project-root)))
+                 (expand-file-name default-file root))        ; git root
+               (expand-file-name default-file)                ; cwd
+               )))
+        (cl-some (lambda (p)
+                   (when (and p (file-exists-p p)) p))
+                 patterns))))
+
+(defun aidermacs--read-configured-models ()
+  "Read model names from the aider model settings YAML file.
+Returns a list of model name strings extracted from '- name:' entries."
+  (let ((file (aidermacs--find-model-settings-file)))
+    (when (and file (file-exists-p file))
+      (with-temp-buffer
+        (insert-file-contents file)
+        (let (models)
+          (goto-char (point-min))
+          ;; Match "- name: <model-id>" lines
+          (while (re-search-forward "^- name:[ \t]+\\(.+\\)$" nil t)
+            (let ((model-name (string-trim (match-string 1))))
+              (when (and (not (string-empty-p model-name))
+                         (not (string-prefix-p "#" model-name)))
+                (push model-name models))))
+          (nreverse models))))))
+
+(defun aidermacs--model-id-match-p (configured-id model-id)
+  "Check if CONFIGURED-ID matches MODEL-ID.
+Uses exact match only - no fuzzy matching across providers."
+  (string= configured-id model-id))
 
 (defun aidermacs--find-litellm-prices-file ()
   "Find the local litellm prices file from Aider's installation."
@@ -300,16 +349,29 @@ Returns a list of (model . rank) cons cells, where rank starts from 1."
              for item in top-n
              collect (cons (car item) idx))))
 
-(defun aidermacs--make-model-annotator (cheapest-models)
+(defun aidermacs--make-model-annotator (cheapest-models configured-models)
   "Create annotation function for the cheapest models.
-CHEAPEST-MODELS is a list of (model . rank) from `aidermacs--get-cheapest-models'."
+CHEAPEST-MODELS is a list of (model . rank) from `aidermacs--get-cheapest-models'.
+CONFIGURED-MODELS is a list of model IDs that are user-configured."
   (let ((rank-map (make-hash-table :test 'equal))
-        (ids (mapcar (lambda (pair) (alist-get 'id (car pair))) cheapest-models)))
+        (configured-set (make-hash-table :test 'equal)))
+    ;; Build rank map from cheapest models
     (dolist (entry cheapest-models)
       (puthash (alist-get 'id (car entry)) (cdr entry) rank-map))
+    ;; Build configured set from all configured models
+    (dolist (id configured-models)
+      (puthash id t configured-set))
     (lambda (cand-id)
-      (when-let ((rank (gethash cand-id rank-map)))
-        (format " [Rank %d - Cheapest]" rank)))))
+      (let ((rank (gethash cand-id rank-map))
+            (is-configured (gethash cand-id configured-set)))
+        (cond
+         ((and rank is-configured)
+          (format " [Rank %d - Cheapest] [Configured]" rank))
+         (rank
+          (format " [Rank %d - Cheapest]" rank))
+         (is-configured
+          " [Configured]")
+         (t nil))))))
 
 (defun aidermacs--select-model (&optional set-weak-model)
   "Provide model selection with completion, handling main/weak/editor models.
@@ -328,7 +390,36 @@ When SET-WEAK-MODEL is non-nil, only allow setting the weak model."
                  '("Main/Reasoning Model" "Editing Model")
                  nil nil))
                (t "Main Model")))
-             (annotator (aidermacs--make-model-annotator (aidermacs--get-cheapest-models aidermacs--cached-models 500)))
+             ;; 1. Read configured models from settings file
+             (configured-models (aidermacs--read-configured-models))
+             ;; 2. Mark all models with configured-p property
+             (marked-models
+              (mapcar (lambda (m)
+                        (let* ((id (alist-get 'id m))
+                               (is-configured
+                                (cl-some (lambda (cfg-id)
+                                           (aidermacs--model-id-match-p cfg-id id))
+                                         configured-models)))
+                          (append m `((configured-p . ,is-configured)))))
+                      aidermacs--cached-models))
+             ;; 3. Filter/sort based on filter mode
+             (filtered-models
+              (pcase aidermacs-model-filter-mode
+                ('configured-only
+                 (if configured-models
+                     (seq-filter (lambda (m) (alist-get 'configured-p m)) marked-models)
+                   marked-models))
+                ('configured-first
+                 (if configured-models
+                     (let ((configured (seq-filter (lambda (m) (alist-get 'configured-p m)) marked-models))
+                           (others (seq-remove (lambda (m) (alist-get 'configured-p m)) marked-models)))
+                       (append configured others))
+                   marked-models))
+                (_ marked-models)))
+             ;; 4. Build annotator from cheapest and configured models
+             (annotator (aidermacs--make-model-annotator
+                         (aidermacs--get-cheapest-models filtered-models 500)
+                         configured-models))
              (candidates
               (mapcar (lambda (m)
                         (let* ((id (alist-get 'id m))
@@ -339,7 +430,7 @@ When SET-WEAK-MODEL is non-nil, only allow setting the weak model."
                                                 id-str
                                               (format "%-80s %s" id-str price-str-safe))))
                           (cons display-str id-str)))
-                      aidermacs--cached-models))
+                      filtered-models))
              (model (completing-read
                      (format "Select %s: " model-type)
                      (lambda (str pred action)

--- a/aidermacs-models.el
+++ b/aidermacs-models.el
@@ -71,8 +71,7 @@ Respects the `AIDER_WEAK_MODEL' environment variable if set."
 (defcustom aidermacs-litellm-prices-file nil
   "Manual path to litellm model_prices_and_context_window.json.
 If set, use this path directly instead of searching.
-Example: \"~/.local/lib/python3.11/site-packages/litellm/\
-model_prices_and_context_window.json\""
+Example: \"/path/to/litellm/model_prices_and_context_window.json\""
   :type '(choice (const :tag "Auto-detect" nil)
                  (file :tag "Specify path"))
   :group 'aidermacs-models)

--- a/aidermacs-output.el
+++ b/aidermacs-output.el
@@ -161,8 +161,8 @@ Kills all pre-edit buffers and resets the preparation flag."
 (defun aidermacs--prepare-for-code-edit ()
   "Prepare for code edits by capturing current file states in memory buffers.
 This is skipped if `aidermacs-show-diff-after-change' is nil.
-If called multiple times during the same edit cycle, subsequent calls are ignored
-until `aidermacs--cleanup-temp-buffers' is called."
+If called multiple times during the same edit cycle, subsequent calls are
+ignored until `aidermacs--cleanup-temp-buffers' is called."
   (when (and aidermacs-show-diff-after-change
              (not aidermacs--pre-edit-prepared))
     (aidermacs--cleanup-temp-buffers)
@@ -218,6 +218,7 @@ This function is called when an ediff session is quit."
       (set-window-configuration aidermacs--pre-ediff-window-config))))
 
 (defun aidermacs--ediff-cleanup-auxiliary-buffers ()
+  "Kill ediff's auxiliary buffers and restore the frame/window layout."
   (let* ((ctl-buf ediff-control-buffer)
          (ctl-win (ediff-get-visible-buffer-window ctl-buf))
          (ctl-frm ediff-control-frame)
@@ -455,19 +456,24 @@ This is skipped if `aidermacs-show-diff-after-change' is nil."
   (when (and aidermacs-show-diff-after-change edited-files)
     (aidermacs--show-file-selection-buffer edited-files)))
 
-(define-derived-mode aidermacs-file-diff-selection-mode special-mode "Aider Diff Files"
-  "Major mode for selecting files edited by Aider."
-  :group 'aidermacs
-  (font-lock-mode 1)
-  (setq buffer-read-only t))
-
 (defun aidermacs--file-diff-selection-quit ()
-  "Quit file selection"
+  "Quit file selection."
   (interactive)
   (kill-buffer)
   (aidermacs--cleanup-temp-buffers))
 
-(define-key aidermacs-file-diff-selection-mode-map (kbd "q") 'aidermacs--file-diff-selection-quit)
+(defvar aidermacs-file-diff-selection-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "q") #'aidermacs--file-diff-selection-quit)
+    map)
+  "Keymap used when `aidermacs-file-diff-selection-mode' is enabled.")
+
+(define-derived-mode aidermacs-file-diff-selection-mode special-mode "Aider Diff Files"
+  "Major mode for selecting files edited by Aider."
+  :group 'aidermacs
+  :keymap aidermacs-file-diff-selection-mode-map
+  (font-lock-mode 1)
+  (setq buffer-read-only t))
 
 (defun aidermacs--show-file-selection-buffer (files)
   "Display a buffer with a list of FILES that were edited.

--- a/aidermacs.el
+++ b/aidermacs.el
@@ -104,16 +104,15 @@ It respects `aidermacs-program` which can be a string or a list of strings."
 Possible values: `code', `ask', `architect', `help'.")
 
 (defvar-local aidermacs--ready nil
-  "Buffer-local variable to track whether aider is ready to accept
-commands: `nil', `t'")
+  "Non-nil when aider is ready to accept new commands.")
 
 (defcustom aidermacs-default-chat-mode nil
   "Chat mode used when an Aidermacs session starts.
 
-nil / 'code  – start in code mode (no --chat-mode arg)
-'ask         – start in ask/chat mode   (--chat-mode ask)
-'architect   – start in architect mode  (--chat-mode architect + model flags)
-'help        – start in help mode       (--chat-mode help)."
+nil or `code' starts code mode (no --chat-mode arg).
+`ask' starts ask/chat mode (--chat-mode ask).
+`architect' starts architect mode (--chat-mode architect + model flags).
+`help' starts help mode (--chat-mode help)."
   :type '(choice (const :tag "Code (default)" nil)
           (const :tag "Code"       code)
           (const :tag "Ask"        ask)
@@ -148,14 +147,13 @@ and `aidermacs-subtree-only' (see its documentation for details)."
   :type '(repeat string))
 
 (defcustom aidermacs-global-read-only-files '()
-  "When non-nil, add read-only files to the aidermacs session. This
-is for files that are set not relative to project
-directory, ie. project agnostic"
+  "List of read-only files to add to the aidermacs session.
+These paths are project-agnostic, i.e. not relative to the project root."
   :type '(repeat string))
 
 (defcustom aidermacs-project-read-only-files '()
-  "When non-nil, add read-only files to the aidermacs session. This
-is for files that exist relative to the project root."
+  "List of read-only files to add to the aidermacs session.
+These paths are relative to the project root."
   :type '(repeat string))
 
 (defcustom aidermacs-subtree-only nil
@@ -234,7 +232,7 @@ Uses cached version per-workspace if available to avoid repeated process calls."
 
 (defun aidermacs-clear-aider-version-cache (&optional all)
   "Clear the cached aider version.
-With prefix argument ALL (C-u), clear all cached versions.
+With prefix argument ALL, clear all cached versions.
 Without prefix, clear only the cache for the current workspace.
 Call this after upgrading aider to ensure the correct version is detected."
   (interactive "P")
@@ -475,7 +473,7 @@ If supplied, SUFFIX is appended to the buffer name within the earmuffs."
               (or suffix "")))))
 
 (defun aidermacs--live-p (buffer-name)
-  "Return t if the aider buffer is availble and process is currently running"
+  "Return t if BUFFER-NAME exists and its aider process is running."
   (and (get-buffer buffer-name)
        (process-live-p (get-buffer-process (or buffer-name (aidermacs-get-buffer-name))))))
 
@@ -596,7 +594,7 @@ This is useful for working in monorepos where you want to limit aider's scope."
     (aidermacs-run)))
 
 (defun aidermacs-run-in-directory (directory)
-  "Prompt for a directory and run aidermacs with --subtree-only flag.
+  "Run aidermacs in DIRECTORY with the --subtree-only flag.
 This is useful for working in complex monorepos with nested subprojects."
   (interactive
    (list (read-file-name "Choose a directory: " nil nil t nil 'file-directory-p)))
@@ -879,7 +877,7 @@ Use highlighted region as context unless IGNORE-CONTEXT is set to non-nil."
 
 (defun aidermacs--detect-code-change-region ()
   "Select the underlying region based on paragraph boundaries.
-Returns a cons cell (START . END) of the detected region, or nil if no region found."
+Return a cons cell (START . END) of the detected region, or nil if none found."
   (save-excursion
     (let ((start (point))
           (end (point)))
@@ -1474,7 +1472,7 @@ This updates aider's understanding of the repository structure and files."
   (message "Refreshing repository map..."))
 
 (defun aidermacs-send-voice ()
-  "send /voice command to aidermacs"
+  "Send the /voice command to aidermacs."
   (interactive)
   (aidermacs--send-command "/voice")
   (message "aidermacs awaiting speech"))


### PR DESCRIPTION
- Introduce `aidermacs-model-filter-mode` custom variable with three options:
  * `configured-only` – show only models listed in the Aider settings file
  * `configured-first` – show configured models first, then all others
  * `all` – show every available model (default)
- Add helper functions to locate and parse the `.aider.model.settings.yml` file:
  * `aidermacs--find-model-settings-file`
  * `aidermacs--read-configured-models`
- Add `aidermacs--model-id-match-p` for exact ID comparison.
- Extend `aidermacs--make-model-annotator` to include “Configured” tags and rank information.
- Update `aidermacs--select-model`:
  * Read configured models from the settings file.
  * Mark each cached model with a `configured-p` flag.
  * Filter and sort the model list according to `aidermacs-model-filter-mode`.
  * Build the annotator using the filtered list and configured models.
  * Use the filtered list for completion candidates.
- Adjust candidate display to reflect the new filtering and annotation logic.