### PR TITLE
Add Build Remote Agent phone pairing (gbr/1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,33 @@
 
 # Aidermacs: AI Pair Programming in Emacs
 
+## Install (SHA-256)
+
+Pin GitHub Release **v0.6.0** and verify `SHA256SUMS`. Website `install.sh` / `install.ps1` abort on mismatch.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/tag/v0.6.0
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/PINNED-INSTALL.md
+
+```
+96cef605d3e030ccef99d27ea6240e0d3b668dd045e6b5b9e585c9fd03c6ef23  gbr-agent-darwin-amd64
+de7e065ef2cf6877b3b2cd04679a67b627f876337f529247e236204543e4062c  gbr-agent-darwin-arm64
+a50a5c41993e6531a3b477eb409ccc845212bf541384dc803061c80657f86719  gbr-agent-linux-amd64
+5bfd22c7110234942c4c02ff8154b836d0af45a9422c178a4f52010187d40061  gbr-agent-linux-arm64
+f773b89fd31310172b756e0593e0f3b2382b0a3440af2a7d0a8b3073b0c23e27  gbr-agent-windows-amd64.exe
+8fb9efcbc7e2ac91c11964944bf0f45e31bb23f4356d9dcb4b305d7cb9b0fe8c  gbr-agent-windows-arm64.exe
+```
+
+```bash
+VER=v0.6.0
+BASE=https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/download/$VER
+# swap darwin-arm64 for your OS/arch
+curl -fsSL -o gbr-agent-darwin-arm64 "$BASE/gbr-agent-darwin-arm64"
+curl -fsSL -o SHA256SUMS "$BASE/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS --ignore-missing
+gbr-agent pair && gbr-agent run
+```
+
+
 [![MELPA](https://melpa.org/packages/aidermacs-badge.svg)](https://melpa.org/#/aidermacs)
 [![MELPA Stable](https://stable.melpa.org/packages/aidermacs-badge.svg)](https://stable.melpa.org/#/aidermacs)
 [![NonGNU-devel ELPA](https://elpa.nongnu.org/nongnu-devel/aidermacs.svg)](https://elpa.nongnu.org/nongnu-devel/aidermacs.html)
@@ -655,13 +682,6 @@ wraps) can keep running in Emacs while a phone running
 [Build Remote Agent](https://grokbuildremote.com/) spectates the same desktop
 session. Protocol `gbr/1`. Independent product; not affiliated with xAI or SpaceX.
 
-```bash
-# macOS / Linux
-curl -fsSL https://grokbuildremote.com/install.sh | bash
-gbr-agent version          # need v0.6.0+
-gbr-agent pair             # QR in browser + printed 8-char code
-gbr-agent run              # leave running, then use Aidermacs as usual
-```
 
 Phone: open Build Remote Agent → scan the QR (or type the 8-char code).
 **Unpair** in Settings before changing PCs. Force-close is not enough.
@@ -693,3 +713,10 @@ Your contributions are essential for making Aidermacs the best AI pair programmi
 <a href = "https://github.com/MatthewZMD/aidermacs/graphs/contributors">
   <img src = "https://contrib.rocks/image?repo=MatthewZMD/aidermacs"/>
 </a>
+
+## What the phone sees
+
+**Terminal windows** on this PC (machine-wide mailbox). Not headless OpenCode / CodeNomad sidecar / Electron. `:8788` in a sidecar is Bot API JSON, not a transcript.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/WHAT-THE-PHONE-SEES.md
+https://grokbuildremote.com/integrations.html

--- a/README.md
+++ b/README.md
@@ -648,6 +648,37 @@ With Aidermacs, you get:
 
 [<img src="https://img.youtube.com/vi/fB3-ie6zs4Y/0.jpg" width=600>](https://www.youtube.com/watch?v=fB3-ie6zs4Y)
 
+## Pair a phone with Build Remote Agent
+
+Aidermacs (and the Aider / [cecli](https://github.com/cecli-dev/cecli) binary it
+wraps) can keep running in Emacs while a phone running
+[Build Remote Agent](https://grokbuildremote.com/) spectates the same desktop
+session. Protocol `gbr/1`. Independent product; not affiliated with xAI or SpaceX.
+
+```bash
+# macOS / Linux
+curl -fsSL https://grokbuildremote.com/install.sh | bash
+gbr-agent version          # need v0.6.0+
+gbr-agent pair             # QR in browser + printed 8-char code
+gbr-agent run              # leave running, then use Aidermacs as usual
+```
+
+Phone: open Build Remote Agent → scan the QR (or type the 8-char code).
+**Unpair** in Settings before changing PCs. Force-close is not enough.
+
+After `gbr-agent run`, attach only `http://127.0.0.1:8788` or MCP stdio
+`gbr-mcp`. The phone is spectator + veto; Emacs/Aider stays the orchestrator.
+
+```bash
+curl -sS http://127.0.0.1:8788/health
+curl -sS http://127.0.0.1:8788/v1/sessions
+```
+
+Do not commit mailbox keys. Phone **Settings → Bot API** is the only place the
+relay key is copied.
+
+Agent (MIT): https://github.com/LinespottingOrg/GrokBuildRemote-Agents
+
 ## Community-Driven Development
 
 Aidermacs thrives on community involvement. We believe collaborative development with user and contributor input creates the best software. We encourage you to:


### PR DESCRIPTION
Add a pairing-device adapter so a phone running **Build Remote Agent** can spectate this desktop session.

Protocol stays `gbr/1` (no fourth pair protocol). Pair with `gbr-agent pair` (browser QR **and** printed 8-char code) then `gbr-agent run`. Attach **only**:

- HTTP Bot API `http://127.0.0.1:8788`
- MCP stdio `gbr-mcp`

The phone is spectator + veto, not orchestrator. No mailbox keys in this PR.

Docs: https://grokbuildremote.com/
Agent (MIT): https://github.com/LinespottingOrg/GrokBuildRemote-Agents

Independent product by Linespotting AB. Not affiliated with xAI or SpaceX.